### PR TITLE
Allow home controllers to view their own training data

### DIFF
--- a/app/Http/Controllers/AdminPublicationCategoriesController.php
+++ b/app/Http/Controllers/AdminPublicationCategoriesController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PublicationCategory;
+use Illuminate\Http\Request;
+
+class AdminPublicationCategoriesController extends Controller
+{
+    public function index()
+    {
+        PublicationCategory::normalizeOrder();
+
+        $categories = PublicationCategory::withCount('publications')
+            ->orderBy('display_order')
+            ->orderBy('title')
+            ->get();
+
+        return view('admin.publications.categories.index', compact('categories'));
+    }
+
+    public function create()
+    {
+        $nextOrder = PublicationCategory::count();
+
+        return view('admin.publications.categories.create', compact('nextOrder'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $this->validateCategory($request);
+        $target = (int) $validated['display_order'];
+        unset($validated['display_order']);
+
+        $new = PublicationCategory::create(array_merge($validated, [
+            'display_order' => PublicationCategory::count() + 1,
+        ]));
+
+        PublicationCategory::repositionAndNormalize($new->id, $target);
+
+        return redirect()
+            ->route('admin.publications.categories.index')
+            ->with('success', 'Category created successfully.');
+    }
+
+    public function edit(int $id)
+    {
+        $category = PublicationCategory::findOrFail($id);
+
+        return view('admin.publications.categories.edit', compact('category'));
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $category = PublicationCategory::findOrFail($id);
+        $validated = $this->validateCategory($request);
+        $target = (int) $validated['display_order'];
+        unset($validated['display_order']);
+
+        $category->update($validated);
+
+        PublicationCategory::repositionAndNormalize($category->id, $target);
+
+        return redirect()
+            ->route('admin.publications.categories.index')
+            ->with('success', 'Category updated successfully.');
+    }
+
+    public function destroy(int $id)
+    {
+        $category = PublicationCategory::withCount('publications')->findOrFail($id);
+
+        if ($category->publications_count > 0) {
+            return redirect()
+                ->route('admin.publications.categories.index')
+                ->with('error', "Cannot delete '{$category->title}' — it still contains {$category->publications_count} document(s). Move or delete them first.");
+        }
+
+        $category->delete();
+        PublicationCategory::normalizeOrder();
+
+        return redirect()
+            ->route('admin.publications.categories.index')
+            ->with('success', 'Category deleted successfully.');
+    }
+
+    private function validateCategory(Request $request): array
+    {
+        return $request->validate([
+            'title'         => ['required', 'string', 'max:255'],
+            'description'   => ['required', 'string'],
+            'display_order' => ['required', 'integer', 'min:0'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/AdminPublicationsController.php
+++ b/app/Http/Controllers/AdminPublicationsController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AdminPublicationsController extends Controller
+{
+    // TODO: Replace static data with Eloquent queries once Publication model is built.
+
+    private function categories(): array
+    {
+        return [
+            'sops'       => 'Standard Operating Procedures',
+            'loas'       => 'Letters of Agreement',
+            'training'   => 'Training Materials',
+            'references' => 'Quick Reference Guides',
+            'maps'       => 'Facility Maps & Charts',
+        ];
+    }
+
+    private function allDocuments(): array
+    {
+        // TODO: Replace with Publication::orderBy('category')->orderBy('name')->get()
+        return [
+            ['id' => 1,  'category' => 'sops',       'name' => 'ZJX ARTCC SOP',                'version' => 'v2.1', 'updated_at' => '2025-01-15 14:22:00', 'description' => 'General facility standard operating procedures.',                 'file_url' => '#'],
+            ['id' => 2,  'category' => 'sops',       'name' => 'Jacksonville Center (ZJX) SOP', 'version' => 'v3.0', 'updated_at' => '2025-03-10 09:47:00', 'description' => 'En-route center operations at ZJX.',                            'file_url' => '#'],
+            ['id' => 3,  'category' => 'sops',       'name' => 'Jacksonville TRACON (JAX) SOP', 'version' => 'v1.5', 'updated_at' => '2025-02-18 02:47:00', 'description' => 'TRACON approach and departure procedures for KJAX.',             'file_url' => '#'],
+            ['id' => 4,  'category' => 'sops',       'name' => 'Tampa TRACON (TPA) SOP',        'version' => 'v2.2', 'updated_at' => '2024-12-05 21:50:11', 'description' => 'TRACON approach and departure procedures for KTPA.',             'file_url' => '#'],
+            ['id' => 5,  'category' => 'sops',       'name' => 'Orlando TRACON (MCO) SOP',      'version' => 'v1.8', 'updated_at' => '2025-01-22 16:30:00', 'description' => 'TRACON approach and departure procedures for KMCO.',            'file_url' => '#'],
+            ['id' => 6,  'category' => 'sops',       'name' => 'Ground/Local SOP',              'version' => 'v1.2', 'updated_at' => '2024-11-30 11:05:00', 'description' => 'Ground and local control procedures for towered airports.',      'file_url' => '#'],
+            ['id' => 7,  'category' => 'loas',       'name' => 'ZJX / ZMA LOA',                 'version' => 'v1.0', 'updated_at' => '2024-10-12 08:00:00', 'description' => 'Agreement between Jacksonville Center and Miami Center.',        'file_url' => '#'],
+            ['id' => 8,  'category' => 'loas',       'name' => 'ZJX / ZTL LOA',                 'version' => 'v1.1', 'updated_at' => '2024-09-03 13:15:00', 'description' => 'Agreement between Jacksonville Center and Atlanta Center.',      'file_url' => '#'],
+            ['id' => 9,  'category' => 'loas',       'name' => 'ZJX / JAX TRACON LOA',          'version' => 'v2.0', 'updated_at' => '2025-01-08 17:44:00', 'description' => 'Internal agreement between ZJX center and JAX TRACON.',         'file_url' => '#'],
+            ['id' => 10, 'category' => 'loas',       'name' => 'ZJX / TPA TRACON LOA',          'version' => 'v1.3', 'updated_at' => '2024-08-20 10:22:00', 'description' => 'Internal agreement between ZJX center and TPA TRACON.',         'file_url' => '#'],
+            ['id' => 11, 'category' => 'training',   'name' => 'S1 Study Guide',                'version' => 'v3.1', 'updated_at' => '2025-02-01 12:00:00', 'description' => 'Observer to Student 1 training guide for ground and delivery.',  'file_url' => '#'],
+            ['id' => 12, 'category' => 'training',   'name' => 'S2 Study Guide',                'version' => 'v2.4', 'updated_at' => '2025-02-14 09:30:00', 'description' => 'Student 1 to Student 2 training guide for local control.',       'file_url' => '#'],
+            ['id' => 13, 'category' => 'training',   'name' => 'S3 Study Guide',                'version' => 'v2.0', 'updated_at' => '2025-03-05 15:10:00', 'description' => 'Student 2 to Student 3 training guide for approach control.',    'file_url' => '#'],
+            ['id' => 14, 'category' => 'training',   'name' => 'C1 Study Guide',                'version' => 'v1.7', 'updated_at' => '2025-01-28 07:55:00', 'description' => 'Student 3 to Controller 1 training guide for en-route control.', 'file_url' => '#'],
+            ['id' => 15, 'category' => 'training',   'name' => 'Training Syllabus',             'version' => 'v4.0', 'updated_at' => '2025-03-20 18:00:00', 'description' => 'vZJX full training programme syllabus and milestones.',         'file_url' => '#'],
+            ['id' => 16, 'category' => 'references', 'name' => 'ZJX Sector Quick Reference',    'version' => 'v1.0', 'updated_at' => '2024-12-11 20:00:00', 'description' => 'Sector boundaries and frequencies at a glance.',                'file_url' => '#'],
+            ['id' => 17, 'category' => 'references', 'name' => 'Phraseology Reference Card',    'version' => 'v2.1', 'updated_at' => '2024-11-07 06:45:00', 'description' => 'Standard and non-standard ATC phraseology reference.',          'file_url' => '#'],
+            ['id' => 18, 'category' => 'references', 'name' => 'ATIS/ASOS Reference',           'version' => 'v1.0', 'updated_at' => '2024-10-25 14:30:00', 'description' => 'ATIS construction and weather reporting reference.',            'file_url' => '#'],
+            ['id' => 19, 'category' => 'maps',       'name' => 'ZJX Airspace Overview',         'version' => 'v2.0', 'updated_at' => '2025-01-19 11:00:00', 'description' => 'Full ZJX ARTCC airspace diagram with sector boundaries.',       'file_url' => '#'],
+            ['id' => 20, 'category' => 'maps',       'name' => 'High Altitude Sectors Map',     'version' => 'v1.3', 'updated_at' => '2024-12-18 02:47:00', 'description' => 'High altitude (FL240+) sector map for ZJX.',                   'file_url' => '#'],
+            ['id' => 21, 'category' => 'maps',       'name' => 'Low Altitude Sectors Map',      'version' => 'v1.5', 'updated_at' => '2024-12-18 03:10:00', 'description' => 'Low altitude (below FL240) sector map for ZJX.',               'file_url' => '#'],
+            ['id' => 22, 'category' => 'maps',       'name' => 'KJAX Airport Diagram',          'version' => 'v1.0', 'updated_at' => '2024-09-14 22:00:00', 'description' => 'Jacksonville International airport surface chart.',             'file_url' => '#'],
+            ['id' => 23, 'category' => 'maps',       'name' => 'KTPA Airport Diagram',          'version' => 'v1.1', 'updated_at' => '2024-09-14 22:15:00', 'description' => 'Tampa International airport surface chart.',                   'file_url' => '#'],
+            ['id' => 24, 'category' => 'maps',       'name' => 'KMCO Airport Diagram',          'version' => 'v1.0', 'updated_at' => '2024-09-14 22:30:00', 'description' => 'Orlando International airport surface chart.',                 'file_url' => '#'],
+        ];
+    }
+
+    public function index()
+    {
+        $documents  = $this->allDocuments();
+        $categories = $this->categories();
+
+        return view('admin.publications.index', compact('documents', 'categories'));
+    }
+
+    public function create()
+    {
+        $categories = $this->categories();
+
+        return view('admin.publications.create', compact('categories'));
+    }
+
+    public function store(Request $request)
+    {
+        // TODO: Validate and persist to database
+        return redirect()->route('admin.publications.index')
+            ->with('success', 'Document created successfully.');
+    }
+
+    public function edit(int $id)
+    {
+        $documents  = $this->allDocuments();
+        $categories = $this->categories();
+
+        $document = collect($documents)->firstWhere('id', $id);
+
+        if (!$document) {
+            abort(404);
+        }
+
+        return view('admin.publications.edit', compact('document', 'categories'));
+    }
+
+    public function update(Request $request, int $id)
+    {
+        // TODO: Validate and update in database
+        return redirect()->route('admin.publications.index')
+            ->with('success', 'Document updated successfully.');
+    }
+
+    public function destroy(int $id)
+    {
+        // TODO: Delete from database
+        return redirect()->route('admin.publications.index')
+            ->with('success', 'Document deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/AdminPublicationsController.php
+++ b/app/Http/Controllers/AdminPublicationsController.php
@@ -2,101 +2,129 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Publication;
+use App\Models\PublicationCategory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 
 class AdminPublicationsController extends Controller
 {
-    // TODO: Replace static data with Eloquent queries once Publication model is built.
+    private const DISK = 'public';
+    private const DIRECTORY = 'documents';
+    private const ALLOWED_MIMES = 'pdf,doc,docx,xls,xlsx,ppt,pptx,png,jpg,jpeg,zip,gz,7z,json,xml,txt';
+    private const MAX_KB = 20480;
 
-    private function categories(): array
-    {
-        return [
-            'sops'       => 'Standard Operating Procedures',
-            'loas'       => 'Letters of Agreement',
-            'training'   => 'Training Materials',
-            'references' => 'Quick Reference Guides',
-            'maps'       => 'Facility Maps & Charts',
-        ];
-    }
-
-    private function allDocuments(): array
-    {
-        // TODO: Replace with Publication::orderBy('category')->orderBy('name')->get()
-        return [
-            ['id' => 1,  'category' => 'sops',       'name' => 'ZJX ARTCC SOP',                'version' => 'v2.1', 'updated_at' => '2025-01-15 14:22:00', 'description' => 'General facility standard operating procedures.',                 'file_url' => '#'],
-            ['id' => 2,  'category' => 'sops',       'name' => 'Jacksonville Center (ZJX) SOP', 'version' => 'v3.0', 'updated_at' => '2025-03-10 09:47:00', 'description' => 'En-route center operations at ZJX.',                            'file_url' => '#'],
-            ['id' => 3,  'category' => 'sops',       'name' => 'Jacksonville TRACON (JAX) SOP', 'version' => 'v1.5', 'updated_at' => '2025-02-18 02:47:00', 'description' => 'TRACON approach and departure procedures for KJAX.',             'file_url' => '#'],
-            ['id' => 4,  'category' => 'sops',       'name' => 'Tampa TRACON (TPA) SOP',        'version' => 'v2.2', 'updated_at' => '2024-12-05 21:50:11', 'description' => 'TRACON approach and departure procedures for KTPA.',             'file_url' => '#'],
-            ['id' => 5,  'category' => 'sops',       'name' => 'Orlando TRACON (MCO) SOP',      'version' => 'v1.8', 'updated_at' => '2025-01-22 16:30:00', 'description' => 'TRACON approach and departure procedures for KMCO.',            'file_url' => '#'],
-            ['id' => 6,  'category' => 'sops',       'name' => 'Ground/Local SOP',              'version' => 'v1.2', 'updated_at' => '2024-11-30 11:05:00', 'description' => 'Ground and local control procedures for towered airports.',      'file_url' => '#'],
-            ['id' => 7,  'category' => 'loas',       'name' => 'ZJX / ZMA LOA',                 'version' => 'v1.0', 'updated_at' => '2024-10-12 08:00:00', 'description' => 'Agreement between Jacksonville Center and Miami Center.',        'file_url' => '#'],
-            ['id' => 8,  'category' => 'loas',       'name' => 'ZJX / ZTL LOA',                 'version' => 'v1.1', 'updated_at' => '2024-09-03 13:15:00', 'description' => 'Agreement between Jacksonville Center and Atlanta Center.',      'file_url' => '#'],
-            ['id' => 9,  'category' => 'loas',       'name' => 'ZJX / JAX TRACON LOA',          'version' => 'v2.0', 'updated_at' => '2025-01-08 17:44:00', 'description' => 'Internal agreement between ZJX center and JAX TRACON.',         'file_url' => '#'],
-            ['id' => 10, 'category' => 'loas',       'name' => 'ZJX / TPA TRACON LOA',          'version' => 'v1.3', 'updated_at' => '2024-08-20 10:22:00', 'description' => 'Internal agreement between ZJX center and TPA TRACON.',         'file_url' => '#'],
-            ['id' => 11, 'category' => 'training',   'name' => 'S1 Study Guide',                'version' => 'v3.1', 'updated_at' => '2025-02-01 12:00:00', 'description' => 'Observer to Student 1 training guide for ground and delivery.',  'file_url' => '#'],
-            ['id' => 12, 'category' => 'training',   'name' => 'S2 Study Guide',                'version' => 'v2.4', 'updated_at' => '2025-02-14 09:30:00', 'description' => 'Student 1 to Student 2 training guide for local control.',       'file_url' => '#'],
-            ['id' => 13, 'category' => 'training',   'name' => 'S3 Study Guide',                'version' => 'v2.0', 'updated_at' => '2025-03-05 15:10:00', 'description' => 'Student 2 to Student 3 training guide for approach control.',    'file_url' => '#'],
-            ['id' => 14, 'category' => 'training',   'name' => 'C1 Study Guide',                'version' => 'v1.7', 'updated_at' => '2025-01-28 07:55:00', 'description' => 'Student 3 to Controller 1 training guide for en-route control.', 'file_url' => '#'],
-            ['id' => 15, 'category' => 'training',   'name' => 'Training Syllabus',             'version' => 'v4.0', 'updated_at' => '2025-03-20 18:00:00', 'description' => 'vZJX full training programme syllabus and milestones.',         'file_url' => '#'],
-            ['id' => 16, 'category' => 'references', 'name' => 'ZJX Sector Quick Reference',    'version' => 'v1.0', 'updated_at' => '2024-12-11 20:00:00', 'description' => 'Sector boundaries and frequencies at a glance.',                'file_url' => '#'],
-            ['id' => 17, 'category' => 'references', 'name' => 'Phraseology Reference Card',    'version' => 'v2.1', 'updated_at' => '2024-11-07 06:45:00', 'description' => 'Standard and non-standard ATC phraseology reference.',          'file_url' => '#'],
-            ['id' => 18, 'category' => 'references', 'name' => 'ATIS/ASOS Reference',           'version' => 'v1.0', 'updated_at' => '2024-10-25 14:30:00', 'description' => 'ATIS construction and weather reporting reference.',            'file_url' => '#'],
-            ['id' => 19, 'category' => 'maps',       'name' => 'ZJX Airspace Overview',         'version' => 'v2.0', 'updated_at' => '2025-01-19 11:00:00', 'description' => 'Full ZJX ARTCC airspace diagram with sector boundaries.',       'file_url' => '#'],
-            ['id' => 20, 'category' => 'maps',       'name' => 'High Altitude Sectors Map',     'version' => 'v1.3', 'updated_at' => '2024-12-18 02:47:00', 'description' => 'High altitude (FL240+) sector map for ZJX.',                   'file_url' => '#'],
-            ['id' => 21, 'category' => 'maps',       'name' => 'Low Altitude Sectors Map',      'version' => 'v1.5', 'updated_at' => '2024-12-18 03:10:00', 'description' => 'Low altitude (below FL240) sector map for ZJX.',               'file_url' => '#'],
-            ['id' => 22, 'category' => 'maps',       'name' => 'KJAX Airport Diagram',          'version' => 'v1.0', 'updated_at' => '2024-09-14 22:00:00', 'description' => 'Jacksonville International airport surface chart.',             'file_url' => '#'],
-            ['id' => 23, 'category' => 'maps',       'name' => 'KTPA Airport Diagram',          'version' => 'v1.1', 'updated_at' => '2024-09-14 22:15:00', 'description' => 'Tampa International airport surface chart.',                   'file_url' => '#'],
-            ['id' => 24, 'category' => 'maps',       'name' => 'KMCO Airport Diagram',          'version' => 'v1.0', 'updated_at' => '2024-09-14 22:30:00', 'description' => 'Orlando International airport surface chart.',                 'file_url' => '#'],
-        ];
-    }
+    private const VIEWABLE_EXTENSIONS = ['pdf', 'png', 'jpg', 'jpeg', 'txt'];
 
     public function index()
     {
-        $documents  = $this->allDocuments();
-        $categories = $this->categories();
+        $categories = PublicationCategory::with(['publications' => function ($query) {
+            $query->orderBy('name');
+        }])
+            ->orderBy('display_order')
+            ->orderBy('title')
+            ->get();
 
-        return view('admin.publications.index', compact('documents', 'categories'));
+        return view('admin.publications.index', compact('categories'));
     }
 
     public function create()
     {
-        $categories = $this->categories();
+        $categories = PublicationCategory::orderBy('display_order')->orderBy('title')->get();
 
         return view('admin.publications.create', compact('categories'));
     }
 
     public function store(Request $request)
     {
-        // TODO: Validate and persist to database
-        return redirect()->route('admin.publications.index')
+        $validated = $this->validatePublication($request, fileRequired: true);
+
+        $file = $request->file('file');
+        $storedPath = $file->store(self::DIRECTORY, self::DISK);
+
+        Publication::create([
+            'publication_category_id' => $validated['publication_category_id'],
+            'name'                    => $validated['name'],
+            'description'             => $validated['description'],
+            'version'                 => $validated['version'],
+            'file_path'               => $storedPath,
+            'original_filename'       => $file->getClientOriginalName(),
+            'file_size'               => $file->getSize(),
+        ]);
+
+        return redirect()
+            ->route('admin.publications.index')
             ->with('success', 'Document created successfully.');
     }
 
     public function edit(int $id)
     {
-        $documents  = $this->allDocuments();
-        $categories = $this->categories();
-
-        $document = collect($documents)->firstWhere('id', $id);
-
-        if (!$document) {
-            abort(404);
-        }
+        $document = Publication::findOrFail($id);
+        $categories = PublicationCategory::orderBy('display_order')->orderBy('title')->get();
 
         return view('admin.publications.edit', compact('document', 'categories'));
     }
 
     public function update(Request $request, int $id)
     {
-        // TODO: Validate and update in database
-        return redirect()->route('admin.publications.index')
+        $document = Publication::findOrFail($id);
+        $validated = $this->validatePublication($request, fileRequired: false);
+
+        $document->fill([
+            'publication_category_id' => $validated['publication_category_id'],
+            'name'                    => $validated['name'],
+            'description'             => $validated['description'],
+            'version'                 => $validated['version'],
+        ]);
+
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+
+            if ($document->file_path && Storage::disk(self::DISK)->exists($document->file_path)) {
+                Storage::disk(self::DISK)->delete($document->file_path);
+            }
+
+            $document->file_path = $file->store(self::DIRECTORY, self::DISK);
+            $document->original_filename = $file->getClientOriginalName();
+            $document->file_size = $file->getSize();
+        }
+
+        $document->save();
+
+        return redirect()
+            ->route('admin.publications.index')
             ->with('success', 'Document updated successfully.');
     }
 
     public function destroy(int $id)
     {
-        // TODO: Delete from database
-        return redirect()->route('admin.publications.index')
+        $document = Publication::findOrFail($id);
+
+        if ($document->file_path && Storage::disk(self::DISK)->exists($document->file_path)) {
+            Storage::disk(self::DISK)->delete($document->file_path);
+        }
+
+        $document->delete();
+
+        return redirect()
+            ->route('admin.publications.index')
             ->with('success', 'Document deleted successfully.');
+    }
+
+    private function validatePublication(Request $request, bool $fileRequired): array
+    {
+        return $request->validate([
+            'publication_category_id' => ['required', Rule::exists('publication_categories', 'id')],
+            'name'                    => ['required', 'string', 'max:255'],
+            'description'             => ['required', 'string'],
+            'version'                 => ['required', 'string', 'max:50'],
+            'file'                    => [
+                $fileRequired ? 'required' : 'nullable',
+                'file',
+                'mimes:' . self::ALLOWED_MIMES,
+                'max:' . self::MAX_KB,
+            ],
+        ]);
     }
 }

--- a/app/Http/Controllers/PublicationsController.php
+++ b/app/Http/Controllers/PublicationsController.php
@@ -2,79 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Models\PublicationCategory;
 
 class PublicationsController extends Controller
 {
     public function index()
     {
-        // TODO: Replace with Eloquent query once Publication model is built.
-        $categories = [
-            [
-                'slug'        => 'sops',
-                'title'       => 'Standard Operating Procedures',
-                'description' => 'Facility-wide and position-specific standard operating procedures for vZJX controllers.',
-                'icon'        => 'document-text',
-                'documents'   => [
-                    ['name' => 'ZJX ARTCC SOP',                'version' => 'v2.1', 'updated_at' => '2025-01-15 14:22:00', 'description' => 'General facility standard operating procedures.',                 'file_url' => '#'],
-                    ['name' => 'Jacksonville Center (ZJX) SOP', 'version' => 'v3.0', 'updated_at' => '2025-03-10 09:47:00', 'description' => 'En-route center operations at ZJX.',                            'file_url' => '#'],
-                    ['name' => 'Jacksonville TRACON (JAX) SOP', 'version' => 'v1.5', 'updated_at' => '2025-02-18 02:47:00', 'description' => 'TRACON approach and departure procedures for KJAX.',             'file_url' => '#'],
-                    ['name' => 'Tampa TRACON (TPA) SOP',        'version' => 'v2.2', 'updated_at' => '2024-12-05 21:50:11', 'description' => 'TRACON approach and departure procedures for KTPA.',             'file_url' => '#'],
-                    ['name' => 'Orlando TRACON (MCO) SOP',      'version' => 'v1.8', 'updated_at' => '2025-01-22 16:30:00', 'description' => 'TRACON approach and departure procedures for KMCO.',            'file_url' => '#'],
-                    ['name' => 'Ground/Local SOP',              'version' => 'v1.2', 'updated_at' => '2024-11-30 11:05:00', 'description' => 'Ground and local control procedures for towered airports.',      'file_url' => '#'],
-                ],
-            ],
-            [
-                'slug'        => 'loas',
-                'title'       => 'Letters of Agreement',
-                'description' => 'Operational agreements between vZJX and adjacent facilities governing coordination procedures.',
-                'icon'        => 'document-duplicate',
-                'documents'   => [
-                    ['name' => 'ZJX / ZMA LOA',        'version' => 'v1.0', 'updated_at' => '2024-10-12 08:00:00', 'description' => 'Agreement between Jacksonville Center and Miami Center.',   'file_url' => '#'],
-                    ['name' => 'ZJX / ZTL LOA',        'version' => 'v1.1', 'updated_at' => '2024-09-03 13:15:00', 'description' => 'Agreement between Jacksonville Center and Atlanta Center.', 'file_url' => '#'],
-                    ['name' => 'ZJX / JAX TRACON LOA', 'version' => 'v2.0', 'updated_at' => '2025-01-08 17:44:00', 'description' => 'Internal agreement between ZJX center and JAX TRACON.',    'file_url' => '#'],
-                    ['name' => 'ZJX / TPA TRACON LOA', 'version' => 'v1.3', 'updated_at' => '2024-08-20 10:22:00', 'description' => 'Internal agreement between ZJX center and TPA TRACON.',    'file_url' => '#'],
-                ],
-            ],
-            [
-                'slug'        => 'training',
-                'title'       => 'Training Materials',
-                'description' => 'Study guides, training syllabi, and reference materials for controller certification.',
-                'icon'        => 'academic-cap',
-                'documents'   => [
-                    ['name' => 'S1 Study Guide',    'version' => 'v3.1', 'updated_at' => '2025-02-01 12:00:00', 'description' => 'Observer to Student 1 training guide for ground and delivery.',       'file_url' => '#'],
-                    ['name' => 'S2 Study Guide',    'version' => 'v2.4', 'updated_at' => '2025-02-14 09:30:00', 'description' => 'Student 1 to Student 2 training guide for local control.',            'file_url' => '#'],
-                    ['name' => 'S3 Study Guide',    'version' => 'v2.0', 'updated_at' => '2025-03-05 15:10:00', 'description' => 'Student 2 to Student 3 training guide for approach control.',         'file_url' => '#'],
-                    ['name' => 'C1 Study Guide',    'version' => 'v1.7', 'updated_at' => '2025-01-28 07:55:00', 'description' => 'Student 3 to Controller 1 training guide for en-route control.',     'file_url' => '#'],
-                    ['name' => 'Training Syllabus', 'version' => 'v4.0', 'updated_at' => '2025-03-20 18:00:00', 'description' => 'vZJX full training programme syllabus and milestones.',              'file_url' => '#'],
-                ],
-            ],
-            [
-                'slug'        => 'references',
-                'title'       => 'Quick Reference Guides',
-                'description' => 'Quick reference cards and cheat sheets for use during controlling sessions.',
-                'icon'        => 'bookmark',
-                'documents'   => [
-                    ['name' => 'ZJX Sector Quick Reference', 'version' => 'v1.0', 'updated_at' => '2024-12-11 20:00:00', 'description' => 'Sector boundaries and frequencies at a glance.',        'file_url' => '#'],
-                    ['name' => 'Phraseology Reference Card', 'version' => 'v2.1', 'updated_at' => '2024-11-07 06:45:00', 'description' => 'Standard and non-standard ATC phraseology reference.',  'file_url' => '#'],
-                    ['name' => 'ATIS/ASOS Reference',        'version' => 'v1.0', 'updated_at' => '2024-10-25 14:30:00', 'description' => 'ATIS construction and weather reporting reference.',    'file_url' => '#'],
-                ],
-            ],
-            [
-                'slug'        => 'maps',
-                'title'       => 'Facility Maps & Charts',
-                'description' => 'Airspace diagrams, sector maps, and facility charts for ZJX ARTCC.',
-                'icon'        => 'map',
-                'documents'   => [
-                    ['name' => 'ZJX Airspace Overview',     'version' => 'v2.0', 'updated_at' => '2025-01-19 11:00:00', 'description' => 'Full ZJX ARTCC airspace diagram with sector boundaries.', 'file_url' => '#'],
-                    ['name' => 'High Altitude Sectors Map', 'version' => 'v1.3', 'updated_at' => '2024-12-18 02:47:00', 'description' => 'High altitude (FL240+) sector map for ZJX.',              'file_url' => '#'],
-                    ['name' => 'Low Altitude Sectors Map',  'version' => 'v1.5', 'updated_at' => '2024-12-18 03:10:00', 'description' => 'Low altitude (below FL240) sector map for ZJX.',         'file_url' => '#'],
-                    ['name' => 'KJAX Airport Diagram',      'version' => 'v1.0', 'updated_at' => '2024-09-14 22:00:00', 'description' => 'Jacksonville International airport surface chart.',        'file_url' => '#'],
-                    ['name' => 'KTPA Airport Diagram',      'version' => 'v1.1', 'updated_at' => '2024-09-14 22:15:00', 'description' => 'Tampa International airport surface chart.',              'file_url' => '#'],
-                    ['name' => 'KMCO Airport Diagram',      'version' => 'v1.0', 'updated_at' => '2024-09-14 22:30:00', 'description' => 'Orlando International airport surface chart.',            'file_url' => '#'],
-                ],
-            ],
-        ];
+        $categories = PublicationCategory::with(['publications' => function ($query) {
+            $query->orderBy('name');
+        }])
+            ->orderBy('display_order')
+            ->orderBy('title')
+            ->get();
 
         return view('publications.index', compact('categories'));
     }

--- a/app/Http/Controllers/PublicationsController.php
+++ b/app/Http/Controllers/PublicationsController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PublicationsController extends Controller
+{
+    public function index()
+    {
+        // TODO: Replace with Eloquent query once Publication model is built.
+        $categories = [
+            [
+                'slug'        => 'sops',
+                'title'       => 'Standard Operating Procedures',
+                'description' => 'Facility-wide and position-specific standard operating procedures for vZJX controllers.',
+                'icon'        => 'document-text',
+                'documents'   => [
+                    ['name' => 'ZJX ARTCC SOP',                'version' => 'v2.1', 'updated_at' => '2025-01-15 14:22:00', 'description' => 'General facility standard operating procedures.',                 'file_url' => '#'],
+                    ['name' => 'Jacksonville Center (ZJX) SOP', 'version' => 'v3.0', 'updated_at' => '2025-03-10 09:47:00', 'description' => 'En-route center operations at ZJX.',                            'file_url' => '#'],
+                    ['name' => 'Jacksonville TRACON (JAX) SOP', 'version' => 'v1.5', 'updated_at' => '2025-02-18 02:47:00', 'description' => 'TRACON approach and departure procedures for KJAX.',             'file_url' => '#'],
+                    ['name' => 'Tampa TRACON (TPA) SOP',        'version' => 'v2.2', 'updated_at' => '2024-12-05 21:50:11', 'description' => 'TRACON approach and departure procedures for KTPA.',             'file_url' => '#'],
+                    ['name' => 'Orlando TRACON (MCO) SOP',      'version' => 'v1.8', 'updated_at' => '2025-01-22 16:30:00', 'description' => 'TRACON approach and departure procedures for KMCO.',            'file_url' => '#'],
+                    ['name' => 'Ground/Local SOP',              'version' => 'v1.2', 'updated_at' => '2024-11-30 11:05:00', 'description' => 'Ground and local control procedures for towered airports.',      'file_url' => '#'],
+                ],
+            ],
+            [
+                'slug'        => 'loas',
+                'title'       => 'Letters of Agreement',
+                'description' => 'Operational agreements between vZJX and adjacent facilities governing coordination procedures.',
+                'icon'        => 'document-duplicate',
+                'documents'   => [
+                    ['name' => 'ZJX / ZMA LOA',        'version' => 'v1.0', 'updated_at' => '2024-10-12 08:00:00', 'description' => 'Agreement between Jacksonville Center and Miami Center.',   'file_url' => '#'],
+                    ['name' => 'ZJX / ZTL LOA',        'version' => 'v1.1', 'updated_at' => '2024-09-03 13:15:00', 'description' => 'Agreement between Jacksonville Center and Atlanta Center.', 'file_url' => '#'],
+                    ['name' => 'ZJX / JAX TRACON LOA', 'version' => 'v2.0', 'updated_at' => '2025-01-08 17:44:00', 'description' => 'Internal agreement between ZJX center and JAX TRACON.',    'file_url' => '#'],
+                    ['name' => 'ZJX / TPA TRACON LOA', 'version' => 'v1.3', 'updated_at' => '2024-08-20 10:22:00', 'description' => 'Internal agreement between ZJX center and TPA TRACON.',    'file_url' => '#'],
+                ],
+            ],
+            [
+                'slug'        => 'training',
+                'title'       => 'Training Materials',
+                'description' => 'Study guides, training syllabi, and reference materials for controller certification.',
+                'icon'        => 'academic-cap',
+                'documents'   => [
+                    ['name' => 'S1 Study Guide',    'version' => 'v3.1', 'updated_at' => '2025-02-01 12:00:00', 'description' => 'Observer to Student 1 training guide for ground and delivery.',       'file_url' => '#'],
+                    ['name' => 'S2 Study Guide',    'version' => 'v2.4', 'updated_at' => '2025-02-14 09:30:00', 'description' => 'Student 1 to Student 2 training guide for local control.',            'file_url' => '#'],
+                    ['name' => 'S3 Study Guide',    'version' => 'v2.0', 'updated_at' => '2025-03-05 15:10:00', 'description' => 'Student 2 to Student 3 training guide for approach control.',         'file_url' => '#'],
+                    ['name' => 'C1 Study Guide',    'version' => 'v1.7', 'updated_at' => '2025-01-28 07:55:00', 'description' => 'Student 3 to Controller 1 training guide for en-route control.',     'file_url' => '#'],
+                    ['name' => 'Training Syllabus', 'version' => 'v4.0', 'updated_at' => '2025-03-20 18:00:00', 'description' => 'vZJX full training programme syllabus and milestones.',              'file_url' => '#'],
+                ],
+            ],
+            [
+                'slug'        => 'references',
+                'title'       => 'Quick Reference Guides',
+                'description' => 'Quick reference cards and cheat sheets for use during controlling sessions.',
+                'icon'        => 'bookmark',
+                'documents'   => [
+                    ['name' => 'ZJX Sector Quick Reference', 'version' => 'v1.0', 'updated_at' => '2024-12-11 20:00:00', 'description' => 'Sector boundaries and frequencies at a glance.',        'file_url' => '#'],
+                    ['name' => 'Phraseology Reference Card', 'version' => 'v2.1', 'updated_at' => '2024-11-07 06:45:00', 'description' => 'Standard and non-standard ATC phraseology reference.',  'file_url' => '#'],
+                    ['name' => 'ATIS/ASOS Reference',        'version' => 'v1.0', 'updated_at' => '2024-10-25 14:30:00', 'description' => 'ATIS construction and weather reporting reference.',    'file_url' => '#'],
+                ],
+            ],
+            [
+                'slug'        => 'maps',
+                'title'       => 'Facility Maps & Charts',
+                'description' => 'Airspace diagrams, sector maps, and facility charts for ZJX ARTCC.',
+                'icon'        => 'map',
+                'documents'   => [
+                    ['name' => 'ZJX Airspace Overview',     'version' => 'v2.0', 'updated_at' => '2025-01-19 11:00:00', 'description' => 'Full ZJX ARTCC airspace diagram with sector boundaries.', 'file_url' => '#'],
+                    ['name' => 'High Altitude Sectors Map', 'version' => 'v1.3', 'updated_at' => '2024-12-18 02:47:00', 'description' => 'High altitude (FL240+) sector map for ZJX.',              'file_url' => '#'],
+                    ['name' => 'Low Altitude Sectors Map',  'version' => 'v1.5', 'updated_at' => '2024-12-18 03:10:00', 'description' => 'Low altitude (below FL240) sector map for ZJX.',         'file_url' => '#'],
+                    ['name' => 'KJAX Airport Diagram',      'version' => 'v1.0', 'updated_at' => '2024-09-14 22:00:00', 'description' => 'Jacksonville International airport surface chart.',        'file_url' => '#'],
+                    ['name' => 'KTPA Airport Diagram',      'version' => 'v1.1', 'updated_at' => '2024-09-14 22:15:00', 'description' => 'Tampa International airport surface chart.',              'file_url' => '#'],
+                    ['name' => 'KMCO Airport Diagram',      'version' => 'v1.0', 'updated_at' => '2024-09-14 22:30:00', 'description' => 'Orlando International airport surface chart.',            'file_url' => '#'],
+                ],
+            ],
+        ];
+
+        return view('publications.index', compact('categories'));
+    }
+}

--- a/app/Http/Controllers/Training/TrainingTicketController.php
+++ b/app/Http/Controllers/Training/TrainingTicketController.php
@@ -91,12 +91,14 @@ class TrainingTicketController extends Controller
             ->with('success', 'Training ticket successfully created.');
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show(string $id)
     {
         $trainingTicket = TrainingTicket::findOrFail($id);
+
+        if (Auth::id() !== $trainingTicket->user_id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         return view('training-tickets.show', compact('trainingTicket'));
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -73,6 +73,10 @@ class UserController extends Controller
     public function trainingAssignments(int $id) {
         $user = User::findOrFail($id);
 
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Training assignments are only available for rostered users.');
         }
@@ -88,6 +92,10 @@ class UserController extends Controller
     public function trainingTickets(int $id) {
         $user = User::findOrFail($id);
 
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Training tickets are only available for rostered users.');
         }
@@ -102,6 +110,11 @@ class UserController extends Controller
 
     public function soloCerts(int $id) {
         $user = User::findOrFail($id);
+
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Solo certifications are only available for rostered users.');
         }

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Publication extends Model
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'description', 'version', 'publication_category_id', 'original_filename'])
+            ->logOnlyDirty();
+    }
+
+    protected $fillable = [
+        'publication_category_id',
+        'name',
+        'description',
+        'version',
+        'file_path',
+        'original_filename',
+        'file_size',
+    ];
+
+    protected $appends = ['file_url'];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(PublicationCategory::class, 'publication_category_id');
+    }
+
+    protected function fileUrl(): Attribute
+    {
+        return Attribute::get(fn () => $this->file_path
+            ? Storage::disk('public')->url($this->file_path)
+            : null);
+    }
+
+    public function isViewableInBrowser(): bool
+    {
+        $ext = strtolower(pathinfo($this->original_filename ?? $this->file_path, PATHINFO_EXTENSION));
+
+        return in_array($ext, ['pdf', 'png', 'jpg', 'jpeg', 'txt']);
+    }
+}

--- a/app/Models/PublicationCategory.php
+++ b/app/Models/PublicationCategory.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class PublicationCategory extends Model
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['title', 'description', 'display_order'])
+            ->logOnlyDirty();
+    }
+
+    public const NAV_CACHE_KEY = 'navbar.publication_categories';
+    private const ORDER_PARK_OFFSET = 1000000;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'display_order',
+    ];
+
+    public function publications(): HasMany
+    {
+        return $this->hasMany(Publication::class);
+    }
+
+    public static function forNavbar()
+    {
+        return Cache::rememberForever(self::NAV_CACHE_KEY, function () {
+            return self::orderBy('display_order')
+                ->orderBy('title')
+                ->get(['id', 'title']);
+        });
+    }
+
+    public static function repositionAndNormalize(int $id, int $targetPosition): void
+    {
+        DB::transaction(function () use ($id, $targetPosition) {
+            $all = self::orderBy('display_order')->orderBy('id')->get();
+            $moving = $all->firstWhere('id', $id);
+
+            if (! $moving) {
+                return;
+            }
+
+            $others = $all->reject(fn ($c) => $c->id === $id)->values();
+            $target = max(0, min($targetPosition, $others->count()));
+
+            $orderedIds = $others->pluck('id')->all();
+            array_splice($orderedIds, $target, 0, [$id]);
+
+            self::writeOrderedIds($orderedIds);
+        });
+    }
+
+    public static function normalizeOrder(): void
+    {
+        DB::transaction(function () {
+            $ordered = self::orderBy('display_order')->orderBy('id')->pluck('id')->all();
+
+            $needsFix = false;
+            foreach ($ordered as $i => $id) {
+                $current = self::whereKey($id)->value('display_order');
+                if ((int) $current !== $i) {
+                    $needsFix = true;
+                    break;
+                }
+            }
+
+            if ($needsFix) {
+                self::writeOrderedIds($ordered);
+            }
+        });
+    }
+
+    private static function writeOrderedIds(array $orderedIds): void
+    {
+        foreach ($orderedIds as $i => $id) {
+            self::whereKey($id)->update(['display_order' => self::ORDER_PARK_OFFSET + $i]);
+        }
+
+        foreach ($orderedIds as $i => $id) {
+            self::whereKey($id)->update(['display_order' => $i]);
+        }
+
+        Cache::forget(self::NAV_CACHE_KEY);
+    }
+
+    protected static function booted(): void
+    {
+        $flush = fn () => Cache::forget(self::NAV_CACHE_KEY);
+
+        static::saved($flush);
+        static::deleted($flush);
+    }
+}

--- a/database/migrations/2026_04_14_100000_create_publications_tables.php
+++ b/database/migrations/2026_04_14_100000_create_publications_tables.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('publication_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description');
+            $table->unsignedInteger('display_order')->unique();
+            $table->timestamps();
+        });
+
+        Schema::create('publications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('publication_category_id')
+                ->constrained('publication_categories')
+                ->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description');
+            $table->string('version');
+            $table->string('file_path');
+            $table->string('original_filename');
+            $table->unsignedBigInteger('file_size')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('publications');
+        Schema::dropIfExists('publication_categories');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,11 +11,17 @@ class DatabaseSeeder extends Seeder
     /**
      * Seed the application's database.
      */
-    public function run(PermissionSeeder $permissionSeeder, UserSeeder $userSeeder, StatisticsPrefixesSeeder $statisticsPrefixes): void
+    public function run(
+        PermissionSeeder $permissionSeeder,
+        UserSeeder $userSeeder,
+        StatisticsPrefixesSeeder $statisticsPrefixes,
+        PublicationCategorySeeder $publicationCategorySeeder,
+    ): void
     {
         $permissionSeeder->run();
         $userSeeder->run();
         $statisticsPrefixes->run();
+        $publicationCategorySeeder->run();
 
         if (App::environment() === 'development') {
             SyncRoster::dispatch();

--- a/database/seeders/PublicationCategorySeeder.php
+++ b/database/seeders/PublicationCategorySeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PublicationCategory;
+use Illuminate\Database\Seeder;
+
+class PublicationCategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categories = [
+            'Standard Operating Procedures' => 'Facility-wide and position-specific standard operating procedures for vZJX controllers.',
+            'Letters of Agreement'          => 'Operational agreements between vZJX and adjacent facilities governing coordination procedures.',
+            'Training Materials'            => 'Study guides, training syllabi, and reference materials for controller certification.',
+            'Quick Reference Guides'        => 'Quick reference cards and cheat sheets for use during controlling sessions.',
+            'Facility Maps & Charts'        => 'Airspace diagrams, sector maps, and facility charts for ZJX ARTCC.',
+        ];
+
+        $order = 0;
+        foreach ($categories as $title => $description) {
+            PublicationCategory::firstOrCreate(
+                ['title' => $title],
+                [
+                    'description'   => $description,
+                    'display_order' => $order,
+                ],
+            );
+            $order++;
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "site-laravel",
             "dependencies": {
                 "@tailwindcss/vite": "^4.1.11",
                 "autoprefixer": "^10.4.20",
@@ -1138,14 +1139,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/baseline-browser-mapping": {
@@ -2062,9 +2063,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2110,10 +2111,13 @@
             "license": "MIT"
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -2333,9 +2337,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2418,9 +2422,9 @@
             }
         },
         "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -22,7 +22,7 @@
         @role('facilities')
             <x-card-component title="Facilities Quick Links">
                 <a class='btn btn-primary mt-5' href="{{ route('statistics-prefixes.index') }}">Statistics Prefixes</a>
-                <a class='btn btn-primary' href="{{ route('statistics-prefixes.index') }}">Document Management</a>
+                <a class='btn btn-primary' href="{{ route('admin.publications.index') }}">Document Management</a>
             </x-card-component>
         @endrole
 

--- a/resources/views/admin/publications/categories/create.blade.php
+++ b/resources/views/admin/publications/categories/create.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.admin')
+
+@section('title', 'New Category')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8 max-w-3xl">
+
+        <a href="{{ route('admin.publications.categories.index') }}" class="btn btn-ghost btn-sm mb-4 gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Categories
+        </a>
+
+        <form method="POST" action="{{ route('admin.publications.categories.store') }}" class="flex flex-col gap-5">
+            @csrf
+
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Category Details</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="title" class="label">Title <span class="text-error">*</span></label>
+                        <input id="title"
+                               name="title"
+                               type="text"
+                               required
+                               placeholder="e.g. Standard Operating Procedures"
+                               value="{{ old('title') }}"
+                               class="input input-bordered w-full @error('title') input-error @enderror" />
+                        @error('title')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                    <div>
+                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <textarea id="description"
+                                  name="description"
+                                  required
+                                  rows="3"
+                                  placeholder="Short description shown on the public page..."
+                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description') }}</textarea>
+                        @error('description')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                    <div>
+                        <label for="display_order" class="label">Display Order <span class="text-error">*</span></label>
+                        <input id="display_order"
+                               name="display_order"
+                               type="number"
+                               min="0"
+                               required
+                               value="{{ old('display_order', $nextOrder) }}"
+                               class="input input-bordered w-full @error('display_order') input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Lower numbers appear first. Inserting at an existing position pushes others down.</p>
+                        @error('display_order')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                </div>
+            </div>
+
+            <div class="flex gap-3">
+                <button type="submit" class="btn btn-primary">Create Category</button>
+                <a href="{{ route('admin.publications.categories.index') }}" class="btn btn-ghost">Cancel</a>
+            </div>
+
+        </form>
+
+    </div>
+@endsection

--- a/resources/views/admin/publications/categories/edit.blade.php
+++ b/resources/views/admin/publications/categories/edit.blade.php
@@ -1,0 +1,69 @@
+@extends('layouts.admin')
+
+@section('title', 'Edit Category')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8 max-w-3xl">
+
+        <a href="{{ route('admin.publications.categories.index') }}" class="btn btn-ghost btn-sm mb-4 gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Categories
+        </a>
+
+        <form method="POST" action="{{ route('admin.publications.categories.update', $category->id) }}" class="flex flex-col gap-5">
+            @csrf
+            @method('PUT')
+
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Category Details</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="title" class="label">Title <span class="text-error">*</span></label>
+                        <input id="title"
+                               name="title"
+                               type="text"
+                               required
+                               value="{{ old('title', $category->title) }}"
+                               class="input input-bordered w-full @error('title') input-error @enderror" />
+                        @error('title')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                    <div>
+                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <textarea id="description"
+                                  name="description"
+                                  required
+                                  rows="3"
+                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $category->description) }}</textarea>
+                        @error('description')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                    <div>
+                        <label for="display_order" class="label">Display Order <span class="text-error">*</span></label>
+                        <input id="display_order"
+                               name="display_order"
+                               type="number"
+                               min="0"
+                               required
+                               value="{{ old('display_order', $category->display_order) }}"
+                               class="input input-bordered w-full @error('display_order') input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Lower numbers appear first. Moving to an existing position pushes others out of the way.</p>
+                        @error('display_order')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror
+                    </div>
+
+                </div>
+            </div>
+
+            <div class="flex gap-3">
+                <button type="submit" class="btn btn-primary">Save Changes</button>
+                <a href="{{ route('admin.publications.categories.index') }}" class="btn btn-ghost">Cancel</a>
+            </div>
+
+        </form>
+
+    </div>
+@endsection

--- a/resources/views/admin/publications/categories/index.blade.php
+++ b/resources/views/admin/publications/categories/index.blade.php
@@ -1,0 +1,89 @@
+@extends('layouts.admin')
+
+@section('title', 'Document Categories')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8">
+
+        <a href="{{ route('admin.publications.index') }}" class="btn btn-ghost btn-sm mb-4 gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Documents
+        </a>
+
+        {{-- Toolbar --}}
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
+            <h1 class="text-xl font-semibold">Document Categories</h1>
+            <a href="{{ route('admin.publications.categories.create') }}" class="btn btn-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+                New Category
+            </a>
+        </div>
+
+
+        @if(session('error'))
+            <div class="alert alert-error mb-4">
+                <span>{{ session('error') }}</span>
+            </div>
+        @endif
+
+        @if($categories->isEmpty())
+            <x-card-component>
+                <p class="text-base-content/60">No categories yet. Create one to get started.</p>
+            </x-card-component>
+        @else
+            <x-card-component>
+                <div class="overflow-x-auto mt-2">
+                    <table class="table table-zebra table-md border-2 border-base-300 w-full">
+                        <thead>
+                            <tr>
+                                <th>Order</th>
+                                <th>Title</th>
+                                <th>Documents</th>
+                                <th>Description</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($categories as $category)
+                                <tr>
+                                    <td class="border-r border-base-300">{{ $category->display_order }}</td>
+                                    <td class="border-r border-base-300 font-medium">{{ $category->title }}</td>
+                                    <td class="border-r border-base-300">
+                                        <span class="badge badge-outline badge-sm">{{ $category->publications_count }}</span>
+                                    </td>
+                                    <td class="border-r border-base-300 text-sm max-w-xs">{{ $category->description }}</td>
+                                    <td>
+                                        <div class="flex flex-wrap gap-2">
+                                            <a href="{{ route('admin.publications.categories.edit', $category->id) }}"
+                                               class="btn btn-primary btn-sm">Edit</a>
+                                            <form action="{{ route('admin.publications.categories.destroy', $category->id) }}"
+                                                  method="POST"
+                                                  class="inline"
+                                                  onsubmit="return confirm('Delete category \'{{ addslashes($category->title) }}\'? This cannot be undone.')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit"
+                                                        class="btn btn-error btn-sm"
+                                                        @disabled($category->publications_count > 0)>
+                                                    Delete
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <p class="text-xs text-base-content/50 mt-3">
+                    Categories that still contain documents cannot be deleted. Move or delete the documents first.
+                </p>
+            </x-card-component>
+        @endif
+
+    </div>
+@endsection

--- a/resources/views/admin/publications/create.blade.php
+++ b/resources/views/admin/publications/create.blade.php
@@ -1,0 +1,131 @@
+@extends('layouts.admin')
+
+@section('title', 'Add Document')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8 max-w-3xl">
+
+        <a href="{{ route('admin.publications.index') }}" class="btn btn-ghost btn-sm mb-4 gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Documents
+        </a>
+
+        <form method="POST" action="{{ route('admin.publications.store') }}" class="flex flex-col gap-5">
+            @csrf
+
+            {{-- Document Details --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Document Details</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="name" class="label">Document Name <span class="text-error">*</span></label>
+                        <input id="name"
+                               name="name"
+                               type="text"
+                               required
+                               placeholder="e.g. ZJX ARTCC SOP"
+                               value="{{ old('name') }}"
+                               class="input input-bordered w-full @error('name') input-error @enderror" />
+                        @error('name')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <textarea id="description"
+                                  name="description"
+                                  required
+                                  rows="3"
+                                  placeholder="Brief description of this document..."
+                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description') }}</textarea>
+                        @error('description')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                </div>
+            </div>
+
+            {{-- Category & Version --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Category & Version</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="category" class="label">Category <span class="text-error">*</span></label>
+                        <select id="category"
+                                name="category"
+                                required
+                                class="select select-bordered w-full @error('category') select-error @enderror">
+                            <option disabled {{ old('category') ? '' : 'selected' }}>Select a category</option>
+                            @foreach($categories as $slug => $label)
+                                <option value="{{ $slug }}" {{ old('category') === $slug ? 'selected' : '' }}>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('category')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="version" class="label">Version <span class="text-error">*</span></label>
+                        <input id="version"
+                               name="version"
+                               type="text"
+                               required
+                               placeholder="e.g. v1.0"
+                               value="{{ old('version') }}"
+                               class="input input-bordered w-full @error('version') input-error @enderror" />
+                        @error('version')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <p class="text-xs text-base-content/50 mt-1">
+                        The "Updated At" timestamp will be set automatically when the document is saved.
+                    </p>
+
+                </div>
+            </div>
+
+            {{-- File URL --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">File URL</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="file_url" class="label">Document URL <span class="text-error">*</span></label>
+                        <input id="file_url"
+                               name="file_url"
+                               type="url"
+                               required
+                               placeholder="https://..."
+                               value="{{ old('file_url') }}"
+                               class="input input-bordered w-full @error('file_url') input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Direct link to the PDF or document file. Must be a publicly accessible URL.</p>
+                        @error('file_url')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                </div>
+            </div>
+
+            <div class="flex gap-3">
+                <button type="submit" class="btn btn-primary">Add Document</button>
+                <a href="{{ route('admin.publications.index') }}" class="btn btn-ghost">Cancel</a>
+            </div>
+
+        </form>
+
+    </div>
+@endsection

--- a/resources/views/admin/publications/create.blade.php
+++ b/resources/views/admin/publications/create.blade.php
@@ -12,7 +12,7 @@
             Back to Documents
         </a>
 
-        <form method="POST" action="{{ route('admin.publications.store') }}" class="flex flex-col gap-5">
+        <form method="POST" action="{{ route('admin.publications.store') }}" enctype="multipart/form-data" class="flex flex-col gap-5">
             @csrf
 
             {{-- Document Details --}}
@@ -58,19 +58,19 @@
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
-                        <label for="category" class="label">Category <span class="text-error">*</span></label>
-                        <select id="category"
-                                name="category"
+                        <label for="publication_category_id" class="label">Category <span class="text-error">*</span></label>
+                        <select id="publication_category_id"
+                                name="publication_category_id"
                                 required
-                                class="select select-bordered w-full @error('category') select-error @enderror">
-                            <option disabled {{ old('category') ? '' : 'selected' }}>Select a category</option>
-                            @foreach($categories as $slug => $label)
-                                <option value="{{ $slug }}" {{ old('category') === $slug ? 'selected' : '' }}>
-                                    {{ $label }}
+                                class="select select-bordered w-full @error('publication_category_id') select-error @enderror">
+                            <option value="" disabled {{ old('publication_category_id') ? '' : 'selected' }}>Select a category</option>
+                            @foreach($categories as $category)
+                                <option value="{{ $category->id }}" {{ (int) old('publication_category_id') === $category->id ? 'selected' : '' }}>
+                                    {{ $category->title }}
                                 </option>
                             @endforeach
                         </select>
-                        @error('category')
+                        @error('publication_category_id')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>
@@ -96,23 +96,22 @@
                 </div>
             </div>
 
-            {{-- File URL --}}
+            {{-- File Upload --}}
             <div class="collapse collapse-open bg-base-100 border border-base-300">
                 <input type="checkbox" checked />
-                <div class="collapse-title font-semibold">File URL</div>
+                <div class="collapse-title font-semibold">File Upload</div>
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
-                        <label for="file_url" class="label">Document URL <span class="text-error">*</span></label>
-                        <input id="file_url"
-                               name="file_url"
-                               type="url"
+                        <label for="file" class="label">Document File <span class="text-error">*</span></label>
+                        <input id="file"
+                               name="file"
+                               type="file"
                                required
-                               placeholder="https://..."
-                               value="{{ old('file_url') }}"
-                               class="input input-bordered w-full @error('file_url') input-error @enderror" />
-                        <p class="text-xs text-base-content/50 mt-1">Direct link to the PDF or document file. Must be a publicly accessible URL.</p>
-                        @error('file_url')
+                               accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.zip,.gz,.7z,.json,.xml,.txt"
+                               class="file-input file-input-bordered w-full @error('file') file-input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Accepted: PDF, Word, Excel, PowerPoint, PNG, JPG, ZIP, JSON, XML, TXT. Max 20 MB.</p>
+                        @error('file')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>

--- a/resources/views/admin/publications/edit.blade.php
+++ b/resources/views/admin/publications/edit.blade.php
@@ -1,0 +1,165 @@
+@extends('layouts.admin')
+
+@section('title', 'Edit Document')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8 max-w-3xl">
+
+        <a href="{{ route('admin.publications.index') }}" class="btn btn-ghost btn-sm mb-4 gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Documents
+        </a>
+
+        <form method="POST" action="{{ route('admin.publications.update', $document['id']) }}" class="flex flex-col gap-5">
+            @csrf
+            @method('PUT')
+
+            {{-- Document Details --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Document Details</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="name" class="label">Document Name <span class="text-error">*</span></label>
+                        <input id="name"
+                               name="name"
+                               type="text"
+                               required
+                               placeholder="e.g. ZJX ARTCC SOP"
+                               value="{{ old('name', $document['name']) }}"
+                               class="input input-bordered w-full @error('name') input-error @enderror" />
+                        @error('name')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <textarea id="description"
+                                  name="description"
+                                  required
+                                  rows="3"
+                                  placeholder="Brief description of this document..."
+                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $document['description']) }}</textarea>
+                        @error('description')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                </div>
+            </div>
+
+            {{-- Category & Version --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">Category & Version</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="category" class="label">Category <span class="text-error">*</span></label>
+                        <select id="category"
+                                name="category"
+                                required
+                                class="select select-bordered w-full @error('category') select-error @enderror">
+                            <option disabled>Select a category</option>
+                            @foreach($categories as $slug => $label)
+                                <option value="{{ $slug }}"
+                                    {{ old('category', $document['category']) === $slug ? 'selected' : '' }}>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('category')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="version" class="label">Version <span class="text-error">*</span></label>
+                        <input id="version"
+                               name="version"
+                               type="text"
+                               required
+                               placeholder="e.g. v1.0"
+                               value="{{ old('version', $document['version']) }}"
+                               class="input input-bordered w-full @error('version') input-error @enderror" />
+                        @error('version')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label class="label">Updated At (UTC)</label>
+                        <div class="input input-bordered w-full flex items-center text-base-content/50 cursor-not-allowed select-none">
+                            {{ \Carbon\Carbon::parse($document['updated_at'])->utc()->format('D, d M Y H:i:s') }} GMT
+                        </div>
+                        <p class="text-xs text-base-content/50 mt-1">Automatically updated when changes are saved.</p>
+                    </div>
+
+                </div>
+            </div>
+
+            {{-- File URL --}}
+            <div class="collapse collapse-open bg-base-100 border border-base-300">
+                <input type="checkbox" checked />
+                <div class="collapse-title font-semibold">File URL</div>
+                <div class="collapse-content flex flex-col gap-4">
+
+                    <div>
+                        <label for="file_url" class="label">Document URL <span class="text-error">*</span></label>
+                        <input id="file_url"
+                               name="file_url"
+                               type="url"
+                               required
+                               placeholder="https://..."
+                               value="{{ old('file_url', $document['file_url']) }}"
+                               class="input input-bordered w-full @error('file_url') input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Direct link to the PDF or document file. Must be a publicly accessible URL.</p>
+                        @error('file_url')
+                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    @if($document['file_url'] && $document['file_url'] !== '#')
+                        <a href="{{ $document['file_url'] }}" target="_blank" class="btn btn-outline btn-sm w-fit gap-1.5">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                            </svg>
+                            View Current File
+                        </a>
+                    @endif
+
+                </div>
+            </div>
+
+            <div class="flex gap-3">
+                <button type="submit" class="btn btn-primary">Save Changes</button>
+                <a href="{{ route('admin.publications.index') }}" class="btn btn-ghost">Cancel</a>
+            </div>
+
+        </form>
+
+        {{-- Danger Zone --}}
+        <div class="mt-8">
+            <x-card-component title="Danger Zone">
+                <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mt-3">
+                    <div>
+                        <p class="font-medium">Delete this document</p>
+                        <p class="text-sm text-base-content/60">Permanently removes this document from the publications list.</p>
+                    </div>
+                    <form action="{{ route('admin.publications.destroy', $document['id']) }}"
+                          method="POST"
+                          onsubmit="return confirm('Delete \'{{ addslashes($document['name']) }}\'? This cannot be undone.')">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-error btn-sm shrink-0">Delete Document</button>
+                    </form>
+                </div>
+            </x-card-component>
+        </div>
+
+    </div>
+@endsection

--- a/resources/views/admin/publications/edit.blade.php
+++ b/resources/views/admin/publications/edit.blade.php
@@ -12,7 +12,7 @@
             Back to Documents
         </a>
 
-        <form method="POST" action="{{ route('admin.publications.update', $document['id']) }}" class="flex flex-col gap-5">
+        <form method="POST" action="{{ route('admin.publications.update', $document->id) }}" enctype="multipart/form-data" class="flex flex-col gap-5">
             @csrf
             @method('PUT')
 
@@ -29,7 +29,7 @@
                                type="text"
                                required
                                placeholder="e.g. ZJX ARTCC SOP"
-                               value="{{ old('name', $document['name']) }}"
+                               value="{{ old('name', $document->name) }}"
                                class="input input-bordered w-full @error('name') input-error @enderror" />
                         @error('name')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
@@ -43,7 +43,7 @@
                                   required
                                   rows="3"
                                   placeholder="Brief description of this document..."
-                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $document['description']) }}</textarea>
+                                  class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $document->description) }}</textarea>
                         @error('description')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
@@ -59,20 +59,20 @@
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
-                        <label for="category" class="label">Category <span class="text-error">*</span></label>
-                        <select id="category"
-                                name="category"
+                        <label for="publication_category_id" class="label">Category <span class="text-error">*</span></label>
+                        <select id="publication_category_id"
+                                name="publication_category_id"
                                 required
-                                class="select select-bordered w-full @error('category') select-error @enderror">
-                            <option disabled>Select a category</option>
-                            @foreach($categories as $slug => $label)
-                                <option value="{{ $slug }}"
-                                    {{ old('category', $document['category']) === $slug ? 'selected' : '' }}>
-                                    {{ $label }}
+                                class="select select-bordered w-full @error('publication_category_id') select-error @enderror">
+                            <option value="" disabled>Select a category</option>
+                            @foreach($categories as $category)
+                                <option value="{{ $category->id }}"
+                                    {{ (int) old('publication_category_id', $document->publication_category_id) === $category->id ? 'selected' : '' }}>
+                                    {{ $category->title }}
                                 </option>
                             @endforeach
                         </select>
-                        @error('category')
+                        @error('publication_category_id')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>
@@ -84,7 +84,7 @@
                                type="text"
                                required
                                placeholder="e.g. v1.0"
-                               value="{{ old('version', $document['version']) }}"
+                               value="{{ old('version', $document->version) }}"
                                class="input input-bordered w-full @error('version') input-error @enderror" />
                         @error('version')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
@@ -94,7 +94,7 @@
                     <div>
                         <label class="label">Updated At (UTC)</label>
                         <div class="input input-bordered w-full flex items-center text-base-content/50 cursor-not-allowed select-none">
-                            {{ \Carbon\Carbon::parse($document['updated_at'])->utc()->format('D, d M Y H:i:s') }} GMT
+                            {{ $document->updated_at->utc()->format('D, d M Y H:i:s') }} GMT
                         </div>
                         <p class="text-xs text-base-content/50 mt-1">Automatically updated when changes are saved.</p>
                     </div>
@@ -102,35 +102,37 @@
                 </div>
             </div>
 
-            {{-- File URL --}}
+            {{-- File Upload --}}
             <div class="collapse collapse-open bg-base-100 border border-base-300">
                 <input type="checkbox" checked />
-                <div class="collapse-title font-semibold">File URL</div>
+                <div class="collapse-title font-semibold">File</div>
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
-                        <label for="file_url" class="label">Document URL <span class="text-error">*</span></label>
-                        <input id="file_url"
-                               name="file_url"
-                               type="url"
-                               required
-                               placeholder="https://..."
-                               value="{{ old('file_url', $document['file_url']) }}"
-                               class="input input-bordered w-full @error('file_url') input-error @enderror" />
-                        <p class="text-xs text-base-content/50 mt-1">Direct link to the PDF or document file. Must be a publicly accessible URL.</p>
-                        @error('file_url')
+                        <label class="label">Current File</label>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <a href="{{ $document->file_url }}" target="_blank" class="btn btn-outline btn-sm gap-1.5">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                                View Current File
+                            </a>
+                            <span class="text-sm text-base-content/60">{{ $document->original_filename }}</span>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label for="file" class="label">Replace File</label>
+                        <input id="file"
+                               name="file"
+                               type="file"
+                               accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.zip,.gz,.7z,.json,.xml,.txt"
+                               class="file-input file-input-bordered w-full @error('file') file-input-error @enderror" />
+                        <p class="text-xs text-base-content/50 mt-1">Leave empty to keep the current file. Accepted: PDF, Word, Excel, PowerPoint, PNG, JPG, ZIP, JSON, XML, TXT. Max 20 MB.</p>
+                        @error('file')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>
-
-                    @if($document['file_url'] && $document['file_url'] !== '#')
-                        <a href="{{ $document['file_url'] }}" target="_blank" class="btn btn-outline btn-sm w-fit gap-1.5">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                            </svg>
-                            View Current File
-                        </a>
-                    @endif
 
                 </div>
             </div>
@@ -150,9 +152,9 @@
                         <p class="font-medium">Delete this document</p>
                         <p class="text-sm text-base-content/60">Permanently removes this document from the publications list.</p>
                     </div>
-                    <form action="{{ route('admin.publications.destroy', $document['id']) }}"
+                    <form action="{{ route('admin.publications.destroy', $document->id) }}"
                           method="POST"
-                          onsubmit="return confirm('Delete \'{{ addslashes($document['name']) }}\'? This cannot be undone.')">
+                          onsubmit="return confirm('Delete \'{{ addslashes($document->name) }}\'? This cannot be undone.')">
                         @csrf
                         @method('DELETE')
                         <button type="submit" class="btn btn-error btn-sm shrink-0">Delete Document</button>

--- a/resources/views/admin/publications/index.blade.php
+++ b/resources/views/admin/publications/index.blade.php
@@ -7,13 +7,21 @@
 
         {{-- Toolbar --}}
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
-            <a href="{{ route('admin.publications.create') }}" class="btn btn-primary w-full sm:w-auto">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-                </svg>
-                New Document
-            </a>
-            <a href="{{ route('publications.index') }}" target="_blank" class="btn btn-outline btn-sm w-full sm:w-auto gap-1.5">
+            <div class="flex flex-wrap gap-2">
+                <a href="{{ route('admin.publications.create') }}" class="btn btn-primary">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                    </svg>
+                    New Document
+                </a>
+                <a href="{{ route('admin.publications.categories.index') }}" class="btn btn-outline">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+                    </svg>
+                    Manage Categories
+                </a>
+            </div>
+            <a href="{{ route('publications.index') }}" target="_blank" class="btn btn-outline btn-sm gap-1.5">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                 </svg>
@@ -21,20 +29,17 @@
             </a>
         </div>
 
-        @if(count($documents) === 0)
+        @if($categories->isEmpty())
             <x-card-component>
-                <p class="text-base-content/60">No documents have been added yet.</p>
+                <p class="text-base-content/60">No publication categories have been configured yet.</p>
             </x-card-component>
         @else
-            {{-- Group documents by category --}}
-            @php
-                $grouped = collect($documents)->groupBy('category');
-            @endphp
-
             <div class="flex flex-col gap-6">
-                @foreach($categories as $slug => $label)
-                    @if($grouped->has($slug))
-                        <x-card-component title="{{ $label }}">
+                @foreach($categories as $category)
+                    <x-card-component title="{{ $category->title }}">
+                        @if($category->publications->isEmpty())
+                            <p class="text-sm text-base-content/50 mt-2">No documents in this category yet.</p>
+                        @else
                             <div class="overflow-x-auto mt-2">
                                 <table class="table table-zebra table-md border-2 border-base-300 w-full">
                                     <thead>
@@ -47,20 +52,20 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @foreach($grouped[$slug] as $doc)
+                                        @foreach($category->publications as $doc)
                                             <tr>
-                                                <td class="border-r border-base-300 font-medium">{{ $doc['name'] }}</td>
+                                                <td class="border-r border-base-300 font-medium">{{ $doc->name }}</td>
                                                 <td class="border-r border-base-300">
-                                                    <span class="badge badge-outline badge-sm">{{ $doc['version'] }}</span>
+                                                    <span class="badge badge-outline badge-sm">{{ $doc->version }}</span>
                                                 </td>
                                                 <td class="border-r border-base-300 text-sm text-base-content/60">
-                                                    {{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('D, d M Y') }}<br>
-                                                    <span class="text-xs">{{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('H:i:s') }} GMT</span>
+                                                    {{ $doc->updated_at->utc()->format('D, d M Y') }}<br>
+                                                    <span class="text-xs">{{ $doc->updated_at->utc()->format('H:i:s') }} GMT</span>
                                                 </td>
-                                                <td class="border-r border-base-300 text-sm max-w-xs">{{ $doc['description'] }}</td>
+                                                <td class="border-r border-base-300 text-sm max-w-xs">{{ $doc->description }}</td>
                                                 <td>
                                                     <div class="flex flex-wrap gap-2">
-                                                        <a href="{{ $doc['file_url'] }}"
+                                                        <a href="{{ $doc->file_url }}"
                                                            target="_blank"
                                                            class="btn btn-ghost btn-sm gap-1"
                                                            title="View in browser">
@@ -70,14 +75,14 @@
                                                             </svg>
                                                             View
                                                         </a>
-                                                        <a href="{{ route('admin.publications.edit', $doc['id']) }}"
+                                                        <a href="{{ route('admin.publications.edit', $doc->id) }}"
                                                            class="btn btn-primary btn-sm">
                                                             Edit
                                                         </a>
-                                                        <form action="{{ route('admin.publications.destroy', $doc['id']) }}"
+                                                        <form action="{{ route('admin.publications.destroy', $doc->id) }}"
                                                               method="POST"
                                                               class="inline"
-                                                              onsubmit="return confirm('Delete \'{{ addslashes($doc['name']) }}\'? This cannot be undone.')">
+                                                              onsubmit="return confirm('Delete \'{{ addslashes($doc->name) }}\'? This cannot be undone.')">
                                                             @csrf
                                                             @method('DELETE')
                                                             <button type="submit" class="btn btn-error btn-sm">Delete</button>
@@ -89,8 +94,8 @@
                                     </tbody>
                                 </table>
                             </div>
-                        </x-card-component>
-                    @endif
+                        @endif
+                    </x-card-component>
                 @endforeach
             </div>
         @endif

--- a/resources/views/admin/publications/index.blade.php
+++ b/resources/views/admin/publications/index.blade.php
@@ -1,0 +1,99 @@
+@extends('layouts.admin')
+
+@section('title', 'Document Management')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8">
+
+        {{-- Toolbar --}}
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
+            <a href="{{ route('admin.publications.create') }}" class="btn btn-primary w-full sm:w-auto">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+                New Document
+            </a>
+            <a href="{{ route('publications.index') }}" target="_blank" class="btn btn-outline btn-sm w-full sm:w-auto gap-1.5">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+                View Public Page
+            </a>
+        </div>
+
+        @if(count($documents) === 0)
+            <x-card-component>
+                <p class="text-base-content/60">No documents have been added yet.</p>
+            </x-card-component>
+        @else
+            {{-- Group documents by category --}}
+            @php
+                $grouped = collect($documents)->groupBy('category');
+            @endphp
+
+            <div class="flex flex-col gap-6">
+                @foreach($categories as $slug => $label)
+                    @if($grouped->has($slug))
+                        <x-card-component title="{{ $label }}">
+                            <div class="overflow-x-auto mt-2">
+                                <table class="table table-zebra table-md border-2 border-base-300 w-full">
+                                    <thead>
+                                        <tr>
+                                            <th>Name</th>
+                                            <th>Version</th>
+                                            <th>Updated At (UTC)</th>
+                                            <th>Description</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach($grouped[$slug] as $doc)
+                                            <tr>
+                                                <td class="border-r border-base-300 font-medium">{{ $doc['name'] }}</td>
+                                                <td class="border-r border-base-300">
+                                                    <span class="badge badge-outline badge-sm">{{ $doc['version'] }}</span>
+                                                </td>
+                                                <td class="border-r border-base-300 text-sm text-base-content/60">
+                                                    {{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('D, d M Y') }}<br>
+                                                    <span class="text-xs">{{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('H:i:s') }} GMT</span>
+                                                </td>
+                                                <td class="border-r border-base-300 text-sm max-w-xs">{{ $doc['description'] }}</td>
+                                                <td>
+                                                    <div class="flex flex-wrap gap-2">
+                                                        <a href="{{ $doc['file_url'] }}"
+                                                           target="_blank"
+                                                           class="btn btn-ghost btn-sm gap-1"
+                                                           title="View in browser">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                                            </svg>
+                                                            View
+                                                        </a>
+                                                        <a href="{{ route('admin.publications.edit', $doc['id']) }}"
+                                                           class="btn btn-primary btn-sm">
+                                                            Edit
+                                                        </a>
+                                                        <form action="{{ route('admin.publications.destroy', $doc['id']) }}"
+                                                              method="POST"
+                                                              class="inline"
+                                                              onsubmit="return confirm('Delete \'{{ addslashes($doc['name']) }}\'? This cannot be undone.')">
+                                                            @csrf
+                                                            @method('DELETE')
+                                                            <button type="submit" class="btn btn-error btn-sm">Delete</button>
+                                                        </form>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </x-card-component>
+                    @endif
+                @endforeach
+            </div>
+        @endif
+
+    </div>
+@endsection

--- a/resources/views/components/admin-navbar.blade.php
+++ b/resources/views/components/admin-navbar.blade.php
@@ -30,7 +30,8 @@
                     <x-dropdown-icon/>
                 </div>
                 <ul tabindex="-1" class="dropdown-content text-base-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm">
-                        <li><a href={{ route('statistics-prefixes.index') }}>Statistics Prefixes</a></li>
+                    <li><a href="{{ route('statistics-prefixes.index') }}">Statistics Prefixes</a></li>
+                    <li><a href="{{ route('admin.publications.index') }}">Document Management</a></li>
                 </ul>
             </div>
         @endhasrole

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -32,6 +32,22 @@
             </ul>
         </div>
 
+        <div class="dropdown">
+            <div tabindex="0" role="button" class="m-1 flex items-center gap-2">
+                <span>Publications</span>
+                <x-dropdown-icon/>
+            </div>
+            <ul tabindex="-1" class="dropdown-content text-base-content menu bg-base-100 rounded-box z-50 w-64 p-2 shadow-sm">
+                <li><a href="{{ route('publications.index') }}">All Documents</a></li>
+                <li class="menu-title text-xs uppercase tracking-wide pt-2">Categories</li>
+                <li><a href="{{ route('publications.index') }}#sops">Standard Operating Procedures</a></li>
+                <li><a href="{{ route('publications.index') }}#loas">Letters of Agreement</a></li>
+                <li><a href="{{ route('publications.index') }}#training">Training Materials</a></li>
+                <li><a href="{{ route('publications.index') }}#references">Quick Reference Guides</a></li>
+                <li><a href="{{ route('publications.index') }}#maps">Facility Maps & Charts</a></li>
+            </ul>
+        </div>
+
         @hasrole('staff')
             <div class="dropdown dropdown-end">
                 <div tabindex="0" role="button" class="m-1 flex items-center gap-2">
@@ -94,6 +110,14 @@
             <li><a href="{{ route('visit.index') }}">Visit vZJX</a></li>
             <li><a href="{{ route('roster.index') }}">Roster</a></li>
             <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
+
+            <li class="menu-title text-xs uppercase tracking-wide pt-2">Publications</li>
+            <li><a href="{{ route('publications.index') }}">All Documents</a></li>
+            <li><a href="{{ route('publications.index') }}#sops">SOPs</a></li>
+            <li><a href="{{ route('publications.index') }}#loas">Letters of Agreement</a></li>
+            <li><a href="{{ route('publications.index') }}#training">Training Materials</a></li>
+            <li><a href="{{ route('publications.index') }}#references">Quick Reference Guides</a></li>
+            <li><a href="{{ route('publications.index') }}#maps">Facility Maps & Charts</a></li>
 
             @hasrole('staff')
                 <li class="menu-title text-xs uppercase tracking-wide pt-2">Facility Admin</li>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -1,3 +1,7 @@
+@php
+    $publicationCategories = \App\Models\PublicationCategory::forNavbar();
+@endphp
+
 <div class="navbar sticky top-0 bg-primary text-primary-content z-20 px-3 sm:px-5">
     {{-- Logo + Home --}}
     <div class="flex-1 min-w-0">
@@ -39,12 +43,12 @@
             </div>
             <ul tabindex="-1" class="dropdown-content text-base-content menu bg-base-100 rounded-box z-50 w-64 p-2 shadow-sm">
                 <li><a href="{{ route('publications.index') }}">All Documents</a></li>
-                <li class="menu-title text-xs uppercase tracking-wide pt-2">Categories</li>
-                <li><a href="{{ route('publications.index') }}#sops">Standard Operating Procedures</a></li>
-                <li><a href="{{ route('publications.index') }}#loas">Letters of Agreement</a></li>
-                <li><a href="{{ route('publications.index') }}#training">Training Materials</a></li>
-                <li><a href="{{ route('publications.index') }}#references">Quick Reference Guides</a></li>
-                <li><a href="{{ route('publications.index') }}#maps">Facility Maps & Charts</a></li>
+                @if($publicationCategories->isNotEmpty())
+                    <li class="menu-title text-xs uppercase tracking-wide pt-2">Categories</li>
+                    @foreach($publicationCategories as $publicationCategory)
+                        <li><a href="{{ route('publications.index') }}#category-{{ $publicationCategory->id }}">{{ $publicationCategory->title }}</a></li>
+                    @endforeach
+                @endif
             </ul>
         </div>
 
@@ -113,11 +117,9 @@
 
             <li class="menu-title text-xs uppercase tracking-wide pt-2">Publications</li>
             <li><a href="{{ route('publications.index') }}">All Documents</a></li>
-            <li><a href="{{ route('publications.index') }}#sops">SOPs</a></li>
-            <li><a href="{{ route('publications.index') }}#loas">Letters of Agreement</a></li>
-            <li><a href="{{ route('publications.index') }}#training">Training Materials</a></li>
-            <li><a href="{{ route('publications.index') }}#references">Quick Reference Guides</a></li>
-            <li><a href="{{ route('publications.index') }}#maps">Facility Maps & Charts</a></li>
+            @foreach($publicationCategories as $publicationCategory)
+                <li><a href="{{ route('publications.index') }}#category-{{ $publicationCategory->id }}">{{ $publicationCategory->title }}</a></li>
+            @endforeach
 
             @hasrole('staff')
                 <li class="menu-title text-xs uppercase tracking-wide pt-2">Facility Admin</li>

--- a/resources/views/components/training-assignment-table.blade.php
+++ b/resources/views/components/training-assignment-table.blade.php
@@ -1,6 +1,6 @@
 @unless(sizeof($trainingAssignments) == 0)
-    <div class="overflow-x-auto">
-    <table class='table table-zebra table-md border-2 border-base-300 mt-5'>
+    <div>
+    <table class='table table-zebra table-md border-2 border-base-300 mt-5 w-full'>
         <thead>
         <tr>
             <th>Student CID</th>
@@ -57,7 +57,7 @@
                         <li>
                             <details>
                                 <summary>Actions</summary>
-                                <ul class="bg-base-100 text-base-content rounded-t-none p-2 z-10">
+                                <ul class="bg-base-100 text-base-content rounded-t-none p-2 z-10 min-w-max">
                                     @haspermission('claim students')
                                     @if (is_null($trainingAssignment->instructor))
                                         <li>

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -11,23 +11,23 @@
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show')])
                     >General Info</a>
 
-                    @role('training')
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.training-tickets", $user) }}' 
+                    @if(Auth::id() == $user->id || Auth::user()->hasRole('training'))
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.training-tickets", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.training-tickets')])
                     >Training Tickets</a>
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.training-assignments", $user) }}' 
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.training-assignments", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.training-assignments')])
                     >Training Assignments</a>
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.solo-certs", $user) }}' 
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.solo-certs", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.solo-certs')])
                     >Solo Certs</a>
-                    @endrole
+                    @endif
                 </div>
                 
             </div>

--- a/resources/views/publications/index.blade.php
+++ b/resources/views/publications/index.blade.php
@@ -13,9 +13,9 @@
         {{-- Category tabs (mobile: scroll horizontally; desktop: inline) --}}
         <div class="flex gap-2 flex-wrap mb-6">
             @foreach($categories as $category)
-                <a href="#{{ $category['slug'] }}"
+                <a href="#category-{{ $category->id }}"
                    class="btn btn-sm btn-outline">
-                    {{ $category['title'] }}
+                    {{ $category->title }}
                 </a>
             @endforeach
         </div>
@@ -23,68 +23,45 @@
         {{-- Categories --}}
         <div class="flex flex-col gap-8">
             @foreach($categories as $category)
-                <section id="{{ $category['slug'] }}" class="scroll-mt-20">
+                <section id="category-{{ $category->id }}" class="scroll-mt-20">
                     <x-card-component>
                         {{-- Category header --}}
-                        <div class="flex items-start gap-3 mb-4">
-                            <div class="p-2 rounded-lg bg-primary/10 text-primary shrink-0">
-                                @if($category['icon'] === 'document-text')
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                    </svg>
-                                @elseif($category['icon'] === 'document-duplicate')
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                    </svg>
-                                @elseif($category['icon'] === 'academic-cap')
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
-                                    </svg>
-                                @elseif($category['icon'] === 'bookmark')
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                                    </svg>
-                                @elseif($category['icon'] === 'map')
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
-                                    </svg>
-                                @endif
-                            </div>
-                            <div>
-                                <h2 class="card-title text-xl sm:text-2xl">{{ $category['title'] }}</h2>
-                                <p class="text-base-content/60 text-sm mt-0.5">{{ $category['description'] }}</p>
-                            </div>
+                        <div class="mb-4">
+                            <h2 class="card-title text-xl sm:text-2xl">{{ $category->title }}</h2>
+                            <p class="text-base-content/60 text-sm mt-0.5">{{ $category->description }}</p>
                         </div>
 
                         {{-- Documents list --}}
                         <div class="flex flex-col divide-y divide-base-200">
-                            @foreach($category['documents'] as $doc)
+                            @forelse($category->publications as $doc)
                                 <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
                                     <div class="flex-1 min-w-0">
                                         <div class="flex flex-wrap items-center gap-2">
-                                            <span class="font-medium text-base">{{ $doc['name'] }}</span>
-                                            <span class="badge badge-outline badge-sm">{{ $doc['version'] }}</span>
+                                            <span class="font-medium text-base">{{ $doc->name }}</span>
+                                            <span class="badge badge-outline badge-sm">{{ $doc->version }}</span>
                                         </div>
-                                        <p class="text-sm text-base-content/60 mt-0.5">{{ $doc['description'] }}</p>
+                                        <p class="text-sm text-base-content/60 mt-0.5">{{ $doc->description }}</p>
                                         <p class="text-xs text-base-content/40 mt-0.5">
-                                            Updated {{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('D, d M Y H:i:s') }} GMT
+                                            Updated {{ $doc->updated_at->utc()->format('D, d M Y H:i:s') }} GMT
                                         </p>
                                     </div>
                                     <div class="shrink-0 flex gap-2">
-                                        <a href="{{ $doc['file_url'] }}"
-                                           target="_blank"
-                                           class="btn btn-outline btn-sm gap-1.5"
-                                           aria-label="View {{ $doc['name'] }} in browser">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                            </svg>
-                                            View
-                                        </a>
-                                        <a href="{{ $doc['file_url'] }}"
-                                           download
+                                        @if($doc->isViewableInBrowser())
+                                            <a href="{{ $doc->file_url }}"
+                                               target="_blank"
+                                               class="btn btn-outline btn-sm gap-1.5"
+                                               aria-label="View {{ $doc->name }} in browser">
+                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                                </svg>
+                                                View
+                                            </a>
+                                        @endif
+                                        <a href="{{ $doc->file_url }}"
+                                           download="{{ $doc->original_filename }}"
                                            class="btn btn-primary btn-sm gap-1.5"
-                                           aria-label="Download {{ $doc['name'] }}">
+                                           aria-label="Download {{ $doc->name }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                                             </svg>
@@ -92,7 +69,9 @@
                                         </a>
                                     </div>
                                 </div>
-                            @endforeach
+                            @empty
+                                <p class="text-sm text-base-content/50 py-3">No documents in this category yet.</p>
+                            @endforelse
                         </div>
                     </x-card-component>
                 </section>

--- a/resources/views/publications/index.blade.php
+++ b/resources/views/publications/index.blade.php
@@ -1,0 +1,103 @@
+@extends('layouts.main')
+
+@section('title', 'Publications & Downloads')
+
+@section('body')
+    <div class="w-full px-4 sm:px-6 lg:px-8">
+
+        {{-- Intro --}}
+        <p class="text-base-content/70 mb-6 max-w-3xl">
+            Official vZJX documents including standard operating procedures, letters of agreement, training materials, quick reference guides, and facility maps. All documents are for simulation use only.
+        </p>
+
+        {{-- Category tabs (mobile: scroll horizontally; desktop: inline) --}}
+        <div class="flex gap-2 flex-wrap mb-6">
+            @foreach($categories as $category)
+                <a href="#{{ $category['slug'] }}"
+                   class="btn btn-sm btn-outline">
+                    {{ $category['title'] }}
+                </a>
+            @endforeach
+        </div>
+
+        {{-- Categories --}}
+        <div class="flex flex-col gap-8">
+            @foreach($categories as $category)
+                <section id="{{ $category['slug'] }}" class="scroll-mt-20">
+                    <x-card-component>
+                        {{-- Category header --}}
+                        <div class="flex items-start gap-3 mb-4">
+                            <div class="p-2 rounded-lg bg-primary/10 text-primary shrink-0">
+                                @if($category['icon'] === 'document-text')
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                    </svg>
+                                @elseif($category['icon'] === 'document-duplicate')
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                    </svg>
+                                @elseif($category['icon'] === 'academic-cap')
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+                                    </svg>
+                                @elseif($category['icon'] === 'bookmark')
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                                    </svg>
+                                @elseif($category['icon'] === 'map')
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                                    </svg>
+                                @endif
+                            </div>
+                            <div>
+                                <h2 class="card-title text-xl sm:text-2xl">{{ $category['title'] }}</h2>
+                                <p class="text-base-content/60 text-sm mt-0.5">{{ $category['description'] }}</p>
+                            </div>
+                        </div>
+
+                        {{-- Documents list --}}
+                        <div class="flex flex-col divide-y divide-base-200">
+                            @foreach($category['documents'] as $doc)
+                                <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+                                    <div class="flex-1 min-w-0">
+                                        <div class="flex flex-wrap items-center gap-2">
+                                            <span class="font-medium text-base">{{ $doc['name'] }}</span>
+                                            <span class="badge badge-outline badge-sm">{{ $doc['version'] }}</span>
+                                        </div>
+                                        <p class="text-sm text-base-content/60 mt-0.5">{{ $doc['description'] }}</p>
+                                        <p class="text-xs text-base-content/40 mt-0.5">
+                                            Updated {{ \Carbon\Carbon::parse($doc['updated_at'])->utc()->format('D, d M Y H:i:s') }} GMT
+                                        </p>
+                                    </div>
+                                    <div class="shrink-0 flex gap-2">
+                                        <a href="{{ $doc['file_url'] }}"
+                                           target="_blank"
+                                           class="btn btn-outline btn-sm gap-1.5"
+                                           aria-label="View {{ $doc['name'] }} in browser">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                            View
+                                        </a>
+                                        <a href="{{ $doc['file_url'] }}"
+                                           download
+                                           class="btn btn-primary btn-sm gap-1.5"
+                                           aria-label="Download {{ $doc['name'] }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                            Download
+                                        </a>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </x-card-component>
+                </section>
+            @endforeach
+        </div>
+
+    </div>
+@endsection

--- a/resources/views/training-tickets/show.blade.php
+++ b/resources/views/training-tickets/show.blade.php
@@ -1,8 +1,9 @@
-@extends('layouts.admin')
+@extends(Auth::user()->hasRole('training') ? 'layouts.admin' : 'layouts.main')
 
 @section('title', 'Training Ticket - #'.$trainingTicket->id)
 
 @section('body')
+    <a href="{{ Auth::user()->hasRole('training') ? route('training-tickets.index') : route('users.show.training-tickets', $trainingTicket->user_id) }}" class="btn btn-ghost mb-4">&larr; Back</a>
     <div class="card card-body bg-base-300 w-full max-w-3xl">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8">
             <x-label label="Session Date" :value="$trainingTicket->session_start"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\EventPositionController;
 use App\Livewire\EventRegistration;
 use App\Http\Controllers\PublicationsController;
 use App\Http\Controllers\AdminPublicationsController;
+use App\Http\Controllers\AdminPublicationCategoriesController;
 
 # Homepage
 Route::get('/', [HomeController::class, 'index'])->name('home');
@@ -99,6 +100,16 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
         Route::get('/',            [AdminPublicationsController::class, 'index'])->name('index');
         Route::get('/create',      [AdminPublicationsController::class, 'create'])->name('create');
         Route::post('/',           [AdminPublicationsController::class, 'store'])->name('store');
+
+        Route::prefix('categories')->name('categories.')->group(function () {
+            Route::get('/',            [AdminPublicationCategoriesController::class, 'index'])->name('index');
+            Route::get('/create',      [AdminPublicationCategoriesController::class, 'create'])->name('create');
+            Route::post('/',           [AdminPublicationCategoriesController::class, 'store'])->name('store');
+            Route::get('/{id}/edit',   [AdminPublicationCategoriesController::class, 'edit'])->name('edit');
+            Route::put('/{id}',        [AdminPublicationCategoriesController::class, 'update'])->name('update');
+            Route::delete('/{id}',     [AdminPublicationCategoriesController::class, 'destroy'])->name('destroy');
+        });
+
         Route::get('/{id}/edit',   [AdminPublicationsController::class, 'edit'])->name('edit');
         Route::put('/{id}',        [AdminPublicationsController::class, 'update'])->name('update');
         Route::delete('/{id}',     [AdminPublicationsController::class, 'destroy'])->name('destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ use App\Http\Controllers\VisitFacilityController;
 use App\Mail\TrainingAssignmentCreated;
 use App\Http\Controllers\EventPositionController;
 use App\Livewire\EventRegistration;
+use App\Http\Controllers\PublicationsController;
+use App\Http\Controllers\AdminPublicationsController;
 
 # Homepage
 Route::get('/', [HomeController::class, 'index'])->name('home');
@@ -61,6 +63,9 @@ Route::prefix('users/{user}')->group(function() {
 # Staff Directory
 Route::get('/staff', [StaffController::class, 'index'])->name('staff.index');
 
+# Publications & Downloads
+Route::get('/publications/downloads', [PublicationsController::class, 'index'])->name('publications.index');
+
 # Training Assignment Creation; TODO: make store
 Route::post('training-assignment/create', [TrainingAssignmentController::class, 'create'])->middleware('auth')->name('training-assignment.create');
 Route::prefix('events')->name('events.')->group(function () {
@@ -87,6 +92,16 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
     # Facilities Dept.
     Route::middleware('permission:manage statistics prefixes')->group(function() {
         Route::resource('statistics-prefixes', StatisticsPrefixesController::class);
+    });
+
+    # Publications Management (Facilities Dept.)
+    Route::middleware('role:facilities')->prefix('publications')->name('admin.publications.')->group(function () {
+        Route::get('/',            [AdminPublicationsController::class, 'index'])->name('index');
+        Route::get('/create',      [AdminPublicationsController::class, 'create'])->name('create');
+        Route::post('/',           [AdminPublicationsController::class, 'store'])->name('store');
+        Route::get('/{id}/edit',   [AdminPublicationsController::class, 'edit'])->name('edit');
+        Route::put('/{id}',        [AdminPublicationsController::class, 'update'])->name('update');
+        Route::delete('/{id}',     [AdminPublicationsController::class, 'destroy'])->name('destroy');
     });
 
     # Logs

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,9 @@ Route::get('/publications/downloads', [PublicationsController::class, 'index'])-
 
 # Training Assignment Creation; TODO: make store
 Route::post('training-assignment/create', [TrainingAssignmentController::class, 'create'])->middleware('auth')->name('training-assignment.create');
+
+# Training ticket view (own or training staff)
+Route::get('training-tickets/{ticket}', [TrainingTicketController::class, 'show'])->middleware('auth')->name('training-tickets.show');
 Route::prefix('events')->name('events.')->group(function () {
     Route::get('/', [EventController::class, 'index'])->name('index');
     Route::get('{event}', [EventController::class, 'show'])->name('show');
@@ -122,7 +125,7 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
 
     # Training Dept.
     Route::prefix('/training')->middleware('role:training')->group(function() {
-        Route::resource('tickets', TrainingTicketController::class)->names('training-tickets');
+        Route::resource('tickets', TrainingTicketController::class, ['except' => ['show']])->names('training-tickets');
         Route::resource('assignments', TrainingAssignmentController::class, ['only' => ['update', 'edit', 'index']])->names('training-assignments');
         Route::resource('solo-certs', SoloCertController::class, ['only' => ['index', 'create', 'update', 'destroy', 'store']])->names('solo-certs');
         Route::put('assignments/claim/{assignment}', [TrainingAssignmentController::class, 'claim'])->name('training-assignments.claim');


### PR DESCRIPTION
## Summary
- Home controllers (non-staff) can now see their own Training Tickets, Training Assignments, and Solo Certs tabs on their profile
- Added 403 guards to prevent viewing other users' training data without the training role
- Moved `training-tickets.show` route outside admin middleware so students can access their own tickets
- Training ticket show page now uses the correct layout (admin vs main) and back button destination based on user role
- Fixed training assignment table width and dropdown clipping issue