### PR TITLE
Allow home controllers to view their own training data

### DIFF
--- a/app/Http/Controllers/Training/TrainingTicketController.php
+++ b/app/Http/Controllers/Training/TrainingTicketController.php
@@ -91,12 +91,14 @@ class TrainingTicketController extends Controller
             ->with('success', 'Training ticket successfully created.');
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show(string $id)
     {
         $trainingTicket = TrainingTicket::findOrFail($id);
+
+        if (Auth::id() !== $trainingTicket->user_id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         return view('training-tickets.show', compact('trainingTicket'));
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -73,6 +73,10 @@ class UserController extends Controller
     public function trainingAssignments(int $id) {
         $user = User::findOrFail($id);
 
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Training assignments are only available for rostered users.');
         }
@@ -88,6 +92,10 @@ class UserController extends Controller
     public function trainingTickets(int $id) {
         $user = User::findOrFail($id);
 
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Training tickets are only available for rostered users.');
         }
@@ -102,6 +110,11 @@ class UserController extends Controller
 
     public function soloCerts(int $id) {
         $user = User::findOrFail($id);
+
+        if (Auth::id() !== $user->id && !Auth::user()->hasRole('training')) {
+            abort(403);
+        }
+
         if (!$user->rostered) {
             return redirect()->back()->with('error', 'Solo certifications are only available for rostered users.');
         }

--- a/resources/views/components/training-assignment-table.blade.php
+++ b/resources/views/components/training-assignment-table.blade.php
@@ -1,6 +1,6 @@
 @unless(sizeof($trainingAssignments) == 0)
-    <div class="overflow-x-auto">
-    <table class='table table-zebra table-md border-2 border-base-300 mt-5'>
+    <div>
+    <table class='table table-zebra table-md border-2 border-base-300 mt-5 w-full'>
         <thead>
         <tr>
             <th>Student CID</th>
@@ -57,7 +57,7 @@
                         <li>
                             <details>
                                 <summary>Actions</summary>
-                                <ul class="bg-base-100 text-base-content rounded-t-none p-2 z-10">
+                                <ul class="bg-base-100 text-base-content rounded-t-none p-2 z-10 min-w-max">
                                     @haspermission('claim students')
                                     @if (is_null($trainingAssignment->instructor))
                                         <li>

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -11,23 +11,23 @@
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show')])
                     >General Info</a>
 
-                    @role('training')
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.training-tickets", $user) }}' 
+                    @if(Auth::id() == $user->id || Auth::user()->hasRole('training'))
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.training-tickets", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.training-tickets')])
                     >Training Tickets</a>
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.training-assignments", $user) }}' 
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.training-assignments", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.training-assignments')])
                     >Training Assignments</a>
-                    <a 
-                    role="tab" 
-                    href='{{ route("users.show.solo-certs", $user) }}' 
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.solo-certs", $user) }}'
                     @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.solo-certs')])
                     >Solo Certs</a>
-                    @endrole
+                    @endif
                 </div>
                 
             </div>

--- a/resources/views/training-tickets/show.blade.php
+++ b/resources/views/training-tickets/show.blade.php
@@ -1,8 +1,9 @@
-@extends('layouts.admin')
+@extends(Auth::user()->hasRole('training') ? 'layouts.admin' : 'layouts.main')
 
 @section('title', 'Training Ticket - #'.$trainingTicket->id)
 
 @section('body')
+    <a href="{{ Auth::user()->hasRole('training') ? route('training-tickets.index') : route('users.show.training-tickets', $trainingTicket->user_id) }}" class="btn btn-ghost mb-4">&larr; Back</a>
     <div class="card card-body bg-base-300 w-full max-w-3xl">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8">
             <x-label label="Session Date" :value="$trainingTicket->session_start"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,9 @@ Route::get('/staff', [StaffController::class, 'index'])->name('staff.index');
 
 # Training Assignment Creation; TODO: make store
 Route::post('training-assignment/create', [TrainingAssignmentController::class, 'create'])->middleware('auth')->name('training-assignment.create');
+
+# Training ticket view (own or training staff)
+Route::get('training-tickets/{ticket}', [TrainingTicketController::class, 'show'])->middleware('auth')->name('training-tickets.show');
 Route::prefix('events')->name('events.')->group(function () {
     Route::get('/', [EventController::class, 'index'])->name('index');
     Route::get('{event}', [EventController::class, 'show'])->name('show');
@@ -96,7 +99,7 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
 
     # Training Dept.
     Route::prefix('/training')->middleware('role:training')->group(function() {
-        Route::resource('tickets', TrainingTicketController::class)->names('training-tickets');
+        Route::resource('tickets', TrainingTicketController::class, ['except' => ['show']])->names('training-tickets');
         Route::resource('assignments', TrainingAssignmentController::class, ['only' => ['update', 'edit', 'index']])->names('training-assignments');
         Route::resource('solo-certs', SoloCertController::class, ['only' => ['index', 'create', 'update', 'destroy', 'store']])->names('solo-certs');
         Route::put('assignments/claim/{assignment}', [TrainingAssignmentController::class, 'claim'])->name('training-assignments.claim');


### PR DESCRIPTION
Closes Issue #88
## Summary
- Home controllers (non-staff) can now see their own Training Tickets, Training Assignments, and Solo Certs tabs on their profile
- Added 403 guards to prevent viewing other users' training data without the training role
- Moved training-tickets.show route outside admin middleware so students can access their own tickets
- Training ticket show page now uses the correct layout (admin vs main) and back button destination based on user role
- Fixed training assignment table width and dropdown clipping issue