### PR TITLE
Controller Statistics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,5 @@ VATSIM_CLIENT_SECRET='something'
 VATUSA_FACILITY='ZJX'
 VATUSA_API_URL='https://api.vatusa.net'
 VATUSA_API_KEY='something'
+
+STATS_SIM_API_KEY='something'

--- a/app/Console/Commands/SyncStatsim.php
+++ b/app/Console/Commands/SyncStatsim.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SyncStatsimSessions;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class SyncStatsim extends Command
+{
+    protected $signature = 'stats:sync {months=12 : Number of past months to sync}';
+    protected $description = 'Sync controller statistics from Statsim (runs synchronously)';
+
+    public function handle(): void
+    {
+        $months = (int) $this->argument('months');
+        $cursor = Carbon::now()->subMonthsNoOverflow($months - 1)->startOfMonth();
+        $end    = Carbon::now()->startOfMonth();
+
+        $this->info("Syncing {$months} months from {$cursor->format('M Y')} to {$end->format('M Y')}...");
+        $bar = $this->output->createProgressBar($months);
+        $bar->start();
+
+        while ($cursor->lessThanOrEqualTo($end)) {
+            (new SyncStatsimSessions($cursor->year, $cursor->month))->handle();
+            $bar->advance();
+            $cursor->addMonthNoOverflow();
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info('Sync complete.');
+    }
+}

--- a/app/Console/Commands/SyncStatsim.php
+++ b/app/Console/Commands/SyncStatsim.php
@@ -8,17 +8,31 @@ use Illuminate\Support\Carbon;
 
 class SyncStatsim extends Command
 {
-    protected $signature = 'stats:sync {months=12 : Number of past months to sync}';
-    protected $description = 'Sync controller statistics from Statsim (runs synchronously)';
+    protected $signature = 'statsim:sync {year : Year to start from} {month : Month to start from (1-12)} {end_month? : Optional end month to sync a range (1-12)}';
+    protected $description = 'Sync controller statistics from Statsim for a specific month or range of months';
 
     public function handle(): void
     {
-        $months = (int) $this->argument('months');
-        $cursor = Carbon::now()->subMonthsNoOverflow($months - 1)->startOfMonth();
-        $end    = Carbon::now()->startOfMonth();
+        $year       = (int) $this->argument('year');
+        $startMonth = (int) $this->argument('month');
+        $endMonth   = $this->argument('end_month') !== null ? (int) $this->argument('end_month') : $startMonth;
 
-        $this->info("Syncing {$months} months from {$cursor->format('M Y')} to {$end->format('M Y')}...");
-        $bar = $this->output->createProgressBar($months);
+        if ($startMonth < 1 || $startMonth > 12 || $endMonth < 1 || $endMonth > 12) {
+            $this->error('Month must be between 1 and 12.');
+            return;
+        }
+
+        if ($endMonth < $startMonth) {
+            $this->error('End month must be greater than or equal to start month.');
+            return;
+        }
+
+        $cursor = Carbon::createFromDate($year, $startMonth, 1);
+        $end    = Carbon::createFromDate($year, $endMonth, 1);
+        $total  = $endMonth - $startMonth + 1;
+
+        $this->info("Syncing {$total} month(s) from {$cursor->format('M Y')} to {$end->format('M Y')}...");
+        $bar = $this->output->createProgressBar($total);
         $bar->start();
 
         while ($cursor->lessThanOrEqualTo($end)) {

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ControllerMonthlyStat;
+use App\Models\ControllerSession;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class StatisticsController extends Controller
+{
+    public function index(Request $request)
+    {
+        $now   = Carbon::now();
+        $year  = (int) $request->query('year', $now->year);
+        $month = $request->query('month', $now->month);
+        $cid   = $request->query('cid');
+
+        if ($year < 2000 || $year > 2100) $year = $now->year;
+        $month = ($month === 'all' || (int) $month === 0) ? 0 : (int) $month;
+        if ($month !== 0 && ($month < 1 || $month > 12)) $month = $now->month;
+
+        $years = ControllerMonthlyStat::select('year')
+            ->distinct()
+            ->orderBy('year', 'desc')
+            ->pluck('year');
+
+        if (!$years->contains($now->year)) {
+            $years = $years->prepend($now->year);
+        }
+
+        $controllers = User::where('rostered', true)
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->get(['id', 'first_name', 'last_name', 'rating']);
+
+        // Individual controller lookup
+        $selectedController = null;
+        $controllerMonthly  = collect();
+        $controllerSessions = collect();
+
+        if ($cid) {
+            $selectedController = User::find($cid);
+
+            if ($selectedController) {
+                $controllerMonthly = ControllerMonthlyStat::where('user_id', $cid)
+                    ->where('year', $year)
+                    ->orderBy('month')
+                    ->get();
+
+                if ($month !== 0) {
+                    $from = Carbon::create($year, $month, 1)->startOfMonth();
+                    $to   = $from->copy()->endOfMonth();
+                    $controllerSessions = ControllerSession::where('user_id', $cid)
+                        ->whereBetween('start', [$from, $to])
+                        ->orderBy('start', 'desc')
+                        ->get();
+                }
+            }
+        }
+
+        // Leaderboard (only shown when no controller selected)
+        if ($month === 0) {
+            $rows = ControllerMonthlyStat::with('user')
+                ->where('year', $year)
+                ->get()
+                ->filter(fn($s) => $s->user !== null)
+                ->groupBy('user_id')
+                ->map(function ($group) {
+                    $first = $group->first();
+                    $first->delivery_hours = $group->sum('delivery_hours');
+                    $first->ground_hours   = $group->sum('ground_hours');
+                    $first->tower_hours    = $group->sum('tower_hours');
+                    $first->approach_hours = $group->sum('approach_hours');
+                    $first->center_hours   = $group->sum('center_hours');
+                    return $first;
+                })
+                ->sortByDesc(fn($s) => $s->totalHours())
+                ->values();
+        } else {
+            $rows = ControllerMonthlyStat::with('user')
+                ->where('year', $year)
+                ->where('month', $month)
+                ->get()
+                ->filter(fn($s) => $s->user !== null)
+                ->sortByDesc(fn($s) => $s->totalHours())
+                ->values();
+        }
+
+        $totals = [
+            'delivery' => $rows->sum('delivery_hours'),
+            'ground'   => $rows->sum('ground_hours'),
+            'tower'    => $rows->sum('tower_hours'),
+            'approach' => $rows->sum('approach_hours'),
+            'center'   => $rows->sum('center_hours'),
+            'total'    => $rows->sum(fn($s) => $s->totalHours()),
+        ];
+
+        $allTimeHours = ControllerMonthlyStat::selectRaw(
+            'SUM(delivery_hours + ground_hours + tower_hours + approach_hours + center_hours) as total'
+        )->value('total') ?? 0;
+
+        $earliest = ControllerMonthlyStat::selectRaw('MIN(year * 100 + month) as ym, MIN(year) as y, MIN(month) as m')->first();
+        $allTimeSince = ($earliest && $earliest->y)
+            ? Carbon::create($earliest->y, $earliest->m, 1)->format('M Y')
+            : null;
+
+        return view('statistics.index', [
+            'stats'               => $rows,
+            'year'                => $year,
+            'month'               => $month,
+            'years'               => $years,
+            'totals'              => $totals,
+            'allTimeHours'        => $allTimeHours,
+            'allTimeSince'        => $allTimeSince,
+            'controllers'         => $controllers,
+            'cid'                 => $cid,
+            'selectedController'  => $selectedController,
+            'controllerMonthly'   => $controllerMonthly,
+            'controllerSessions'  => $controllerSessions,
+        ]);
+    }
+}

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\SyncStatsimSessions;
 use App\Models\ControllerMonthlyStat;
 use App\Models\ControllerSession;
 use App\Models\User;
@@ -10,14 +11,42 @@ use Illuminate\Support\Carbon;
 
 class StatisticsController extends Controller
 {
+    public function sync(Request $request)
+    {
+        $request->validate([
+            'from_year'  => 'required|integer|min:2000|max:2100',
+            'from_month' => 'required|integer|min:1|max:12',
+            'to_year'    => 'required|integer|min:2000|max:2100',
+            'to_month'   => 'required|integer|min:1|max:12',
+        ]);
+
+        $from = Carbon::create($request->from_year, $request->from_month, 1)->startOfMonth();
+        $to   = Carbon::create($request->to_year, $request->to_month, 1)->startOfMonth();
+
+        if ($from->greaterThan($to)) {
+            return back()->withErrors(['from' => 'Start date must be before or equal to end date.']);
+        }
+
+        $count = 0;
+        $cursor = $from->copy();
+        while ($cursor->lessThanOrEqualTo($to)) {
+            SyncStatsimSessions::dispatch($cursor->year, $cursor->month);
+            $cursor->addMonthNoOverflow();
+            $count++;
+        }
+
+        return back()->with('success', "Queued sync for {$count} month(s): {$from->format('M Y')} – {$to->format('M Y')}.");
+    }
+
     public function index(Request $request)
     {
         $now   = Carbon::now();
-        $year  = (int) $request->query('year', $now->year);
+        $yearParam = $request->query('year', $now->year);
+        $year  = ($yearParam === 'all' || (int) $yearParam === 0) ? 0 : (int) $yearParam;
         $month = $request->query('month', $now->month);
         $cid   = $request->query('cid');
 
-        if ($year < 2000 || $year > 2100) $year = $now->year;
+        if ($year !== 0 && ($year < 2000 || $year > 2100)) $year = $now->year;
         $month = ($month === 'all' || (int) $month === 0) ? 0 : (int) $month;
         if ($month !== 0 && ($month < 1 || $month > 12)) $month = $now->month;
 
@@ -44,12 +73,14 @@ class StatisticsController extends Controller
             $selectedController = User::find($cid);
 
             if ($selectedController) {
-                $controllerMonthly = ControllerMonthlyStat::where('user_id', $cid)
-                    ->where('year', $year)
+                $monthlyQuery = ControllerMonthlyStat::where('user_id', $cid);
+                if ($year !== 0) $monthlyQuery->where('year', $year);
+                $controllerMonthly = $monthlyQuery
+                    ->orderBy('year')
                     ->orderBy('month')
                     ->get();
 
-                if ($month !== 0) {
+                if ($month !== 0 && $year !== 0) {
                     $from = Carbon::create($year, $month, 1)->startOfMonth();
                     $to   = $from->copy()->endOfMonth();
                     $controllerSessions = ControllerSession::where('user_id', $cid)
@@ -61,9 +92,12 @@ class StatisticsController extends Controller
         }
 
         // Leaderboard (only shown when no controller selected)
+        $leaderboardQuery = ControllerMonthlyStat::with('user');
+        if ($year !== 0) $leaderboardQuery->where('year', $year);
+        if ($month !== 0) $leaderboardQuery->where('month', $month);
+
         if ($month === 0) {
-            $rows = ControllerMonthlyStat::with('user')
-                ->where('year', $year)
+            $rows = $leaderboardQuery
                 ->get()
                 ->filter(fn($s) => $s->user !== null)
                 ->groupBy('user_id')
@@ -79,9 +113,7 @@ class StatisticsController extends Controller
                 ->sortByDesc(fn($s) => $s->totalHours())
                 ->values();
         } else {
-            $rows = ControllerMonthlyStat::with('user')
-                ->where('year', $year)
-                ->where('month', $month)
+            $rows = $leaderboardQuery
                 ->get()
                 ->filter(fn($s) => $s->user !== null)
                 ->sortByDesc(fn($s) => $s->totalHours())

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ControllerMonthlyStat;
+use App\Models\ControllerSession;
 use App\Models\TrainingAssignment;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Log;
 
@@ -15,9 +18,30 @@ class UserController extends Controller
 
     public function show(int $id) {
         $user = User::findOrFail($id);
+        $now  = Carbon::now();
+
+        $allStats = ControllerMonthlyStat::where('user_id', $id)->get();
+
+        $totalHours = $allStats->sum(fn($s) => $s->totalHours());
+        $monthHours = $allStats
+            ->where('year', $now->year)
+            ->where('month', $now->month)
+            ->sum(fn($s) => $s->totalHours());
+        $yearHours  = $allStats
+            ->where('year', $now->year)
+            ->sum(fn($s) => $s->totalHours());
+
+        $recentSessions = ControllerSession::where('user_id', $id)
+            ->orderBy('start', 'desc')
+            ->limit(10)
+            ->get();
 
         return view('users.show', [
-            'user' => $user,
+            'user'           => $user,
+            'totalHours'     => $totalHours,
+            'monthHours'     => $monthHours,
+            'yearHours'      => $yearHours,
+            'recentSessions' => $recentSessions,
         ]);
     }
 

--- a/app/Jobs/SyncStatsimSessions.php
+++ b/app/Jobs/SyncStatsimSessions.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ControllerMonthlyStat;
+use App\Models\ControllerSession;
+use App\Models\StatisticsPrefixes;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SyncStatsimSessions implements ShouldQueue
+{
+    use Queueable;
+
+    public int $timeout = 300;
+
+    public function __construct(public int $year, public int $month) {}
+
+    public function handle(): void
+    {
+        $from = Carbon::create($this->year, $this->month, 1)->startOfMonth();
+        $to = $from->copy()->endOfMonth();
+
+        $response = Http::timeout(60)
+            ->withHeaders(['X-Api-Key' => config('app.stats_sim_api_key') ?? ''])
+            ->get('https://api.statsim.net/api/atcsessions/dates', [
+                'from' => $from->format('n/j/Y'),
+                'to' => $to->format('n/j/Y'),
+            ]);
+
+        if (!$response->successful()) {
+            Log::error('Statsim sync failed', [
+                'status' => $response->status(),
+                'body' => Str::limit($response->body(), 500),
+                'year' => $this->year,
+                'month' => $this->month,
+            ]);
+            return;
+        }
+
+        $sessions = $response->json() ?? [];
+        if (!is_array($sessions)) {
+            Log::error('Statsim sync returned non-array payload', ['year' => $this->year, 'month' => $this->month]);
+            return;
+        }
+
+        $prefixes = StatisticsPrefixes::pluck('name')->toArray();
+        $rosteredCids = User::where('rostered', true)->pluck('id')->flip();
+        $touchedUserIds = [];
+
+        foreach ($sessions as $session) {
+            $callsign = $session['callsign'] ?? null;
+            $vatsimId = $session['vatsimid'] ?? null;
+            $sessionId = $session['id'] ?? null;
+            $loggedOn = $session['loggedOn'] ?? null;
+            $loggedOff = $session['loggedOff'] ?? null;
+
+            if (!$callsign || !$vatsimId || !$sessionId || !$loggedOn || !$loggedOff) {
+                continue;
+            }
+
+            if (!Str::startsWith($callsign, $prefixes)) {
+                continue;
+            }
+
+            $userId = (int) $vatsimId;
+            if (!$rosteredCids->has($userId)) {
+                continue;
+            }
+
+            $facilityLevel = $this->facilityLevel(Str::upper(Str::substr($callsign, -3)));
+            if ($facilityLevel < 2) {
+                continue;
+            }
+
+            ControllerSession::updateOrCreate(
+                ['id' => (int) $sessionId],
+                [
+                    'callsign' => $callsign,
+                    'user_id' => $userId,
+                    'facility_level' => $facilityLevel,
+                    'start' => $loggedOn,
+                    'end' => $loggedOff,
+                ]
+            );
+
+            $touchedUserIds[$userId] = true;
+        }
+
+        foreach (array_keys($touchedUserIds) as $userId) {
+            $this->recomputeMonthlyStats($userId, $this->year, $this->month);
+        }
+    }
+
+    private function facilityLevel(string $suffix): int
+    {
+        return match ($suffix) {
+            'DEL' => 2,
+            'GND' => 3,
+            'TWR' => 4,
+            'APP', 'DEP' => 5,
+            'CTR', 'FSS' => 6,
+            default => 0,
+        };
+    }
+
+    private function recomputeMonthlyStats(int $userId, int $year, int $month): void
+    {
+        $from = Carbon::create($year, $month, 1)->startOfMonth();
+        $to = $from->copy()->endOfMonth();
+
+        $sessions = ControllerSession::where('user_id', $userId)
+            ->whereBetween('start', [$from, $to])
+            ->get();
+
+        $hours = [2 => 0.0, 3 => 0.0, 4 => 0.0, 5 => 0.0, 6 => 0.0];
+
+        foreach ($sessions as $session) {
+            $duration = $session->end->diffInSeconds($session->start, true) / 3600;
+            if (isset($hours[$session->facility_level])) {
+                $hours[$session->facility_level] += $duration;
+            }
+        }
+
+        ControllerMonthlyStat::updateOrCreate(
+            ['user_id' => $userId, 'year' => $year, 'month' => $month],
+            [
+                'delivery_hours' => $hours[2],
+                'ground_hours' => $hours[3],
+                'tower_hours' => $hours[4],
+                'approach_hours' => $hours[5],
+                'center_hours' => $hours[6],
+            ]
+        );
+    }
+}

--- a/app/Models/ControllerMonthlyStat.php
+++ b/app/Models/ControllerMonthlyStat.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ControllerMonthlyStat extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'year',
+        'month',
+        'delivery_hours',
+        'ground_hours',
+        'tower_hours',
+        'approach_hours',
+        'center_hours',
+    ];
+
+    protected $casts = [
+        'year' => 'integer',
+        'month' => 'integer',
+        'delivery_hours' => 'float',
+        'ground_hours' => 'float',
+        'tower_hours' => 'float',
+        'approach_hours' => 'float',
+        'center_hours' => 'float',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function totalHours(): float
+    {
+        return $this->delivery_hours
+            + $this->ground_hours
+            + $this->tower_hours
+            + $this->approach_hours
+            + $this->center_hours;
+    }
+}

--- a/app/Models/ControllerSession.php
+++ b/app/Models/ControllerSession.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ControllerSession extends Model
+{
+    public $timestamps = false;
+    public $incrementing = false;
+    protected $keyType = 'int';
+
+    protected $fillable = [
+        'id',
+        'callsign',
+        'user_id',
+        'facility_level',
+        'start',
+        'end',
+    ];
+
+    protected $casts = [
+        'start' => 'datetime',
+        'end' => 'datetime',
+        'facility_level' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function durationHours(): float
+    {
+        return $this->end->diffInSeconds($this->start, true) / 3600;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -130,5 +130,6 @@ return [
     'vatsim_auth_url' => env('VATSIM_AUTH_URL'),
     'vatusa_facility' => env('VATUSA_FACILITY'),
     'vatsim_api_url' => env('VATSIM_API_URL'),
+    'stats_sim_api_key' => env('STATS_SIM_API_KEY'),
     'training_request_webhook_url' => env('TRAINING_REQUEST_WEBHOOK_URL'),
 ];

--- a/database/migrations/2026_04_23_120000_create_controller_statistics_tables.php
+++ b/database/migrations/2026_04_23_120000_create_controller_statistics_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('controller_sessions', function (Blueprint $table) {
+            $table->unsignedBigInteger('id')->primary();
+            $table->string('callsign');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->unsignedTinyInteger('facility_level');
+            $table->dateTime('start');
+            $table->dateTime('end');
+            $table->index(['user_id', 'start']);
+            $table->index('start');
+        });
+
+        Schema::create('controller_monthly_stats', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->unsignedSmallInteger('year');
+            $table->unsignedTinyInteger('month');
+            $table->decimal('delivery_hours', 8, 4)->default(0);
+            $table->decimal('ground_hours', 8, 4)->default(0);
+            $table->decimal('tower_hours', 8, 4)->default(0);
+            $table->decimal('approach_hours', 8, 4)->default(0);
+            $table->decimal('center_hours', 8, 4)->default(0);
+            $table->unique(['user_id', 'year', 'month']);
+            $table->index(['year', 'month']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('controller_monthly_stats');
+        Schema::dropIfExists('controller_sessions');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
     /**
      * Seed the application's database.
      */
-    public function run(PermissionSeeder $permissionSeeder, UserSeeder $userSeeder, StatisticsPrefixesSeeder $statisticsPrefixes): void
+    public function run(PermissionSeeder $permissionSeeder, UserSeeder $userSeeder, StatisticsPrefixesSeeder $statisticsPrefixes, StatsSyncSeeder $statsSyncSeeder): void
     {
         $permissionSeeder->run();
         $userSeeder->run();
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
 
         if (App::environment() === 'development') {
             SyncRoster::dispatch();
+            $statsSyncSeeder->run();
         }
     }
 }

--- a/database/seeders/StatsSyncSeeder.php
+++ b/database/seeders/StatsSyncSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Jobs\SyncStatsimSessions;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class StatsSyncSeeder extends Seeder
+{
+    private const BACKFILL_MONTHS = 12;
+
+    public function run(): void
+    {
+        $cursor = Carbon::now()->subMonthsNoOverflow(self::BACKFILL_MONTHS - 1)->startOfMonth();
+        $end = Carbon::now()->startOfMonth();
+
+        while ($cursor->lessThanOrEqualTo($end)) {
+            SyncStatsimSessions::dispatch($cursor->year, $cursor->month);
+            $cursor->addMonthNoOverflow();
+        }
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+[x-cloak] { display: none !important; }
+
 @source '../views';
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 
@@ -79,6 +81,7 @@
     --size-selector: 0.25rem;
     --size-field: 0.25rem;
     --border: 1px;
+    --font: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;
 }
 
 :root {

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -26,6 +26,63 @@
             </x-card-component>
         @endrole
 
+        @can('manage statistics prefixes')
+            <x-card-component title="Web Links">
+                @if(session('success'))
+                    <p class="text-success mt-4 text-sm">{{ session('success') }}</p>
+                @endif
+                @error('from')
+                    <p class="text-error mt-4 text-sm">{{ $message }}</p>
+                @enderror
+
+                <form method="POST" action="{{ route('statistics.sync') }}" class="mt-5 space-y-3">
+                    @csrf
+                    @php
+                        $months = range(1, 12);
+                        $years  = range(2020, now()->year);
+                    @endphp
+                    <p class="text-sm font-semibold">Sync StatsSim Statistics</p>
+                    <div class="flex flex-wrap gap-3 items-end">
+                        <div class="flex flex-col gap-1">
+                            <label class="text-xs text-base-content/60">From</label>
+                            <div class="flex gap-2">
+                                <select name="from_year" class="select select-sm" style="min-width: 5.5rem">
+                                    @foreach($years as $y)
+                                        <option value="{{ $y }}" @selected(old('from_year', now()->subMonthNoOverflow()->year) == $y)>{{ $y }}</option>
+                                    @endforeach
+                                </select>
+                                <select name="from_month" class="select select-sm">
+                                    @foreach($months as $m)
+                                        <option value="{{ $m }}" @selected(old('from_month', now()->subMonthNoOverflow()->month) == $m)>
+                                            {{ \Illuminate\Support\Carbon::create(null, $m)->format('M') }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <label class="text-xs text-base-content/60">To</label>
+                            <div class="flex gap-2">
+                                <select name="to_year" class="select select-sm" style="min-width: 5.5rem">
+                                    @foreach($years as $y)
+                                        <option value="{{ $y }}" @selected(old('to_year', now()->year) == $y)>{{ $y }}</option>
+                                    @endforeach
+                                </select>
+                                <select name="to_month" class="select select-sm">
+                                    @foreach($months as $m)
+                                        <option value="{{ $m }}" @selected(old('to_month', now()->month) == $m)>
+                                            {{ \Illuminate\Support\Carbon::create(null, $m)->format('M') }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm">Sync</button>
+                    </div>
+                </form>
+            </x-card-component>
+        @endcan
+
         @role('events')
             <x-card-component title="Events Quick Links">
                 <a class='btn btn-primary mt-5' href="{{ route('admin.events.index') }}">Manage Events</a>

--- a/resources/views/components/assistant-staff.blade.php
+++ b/resources/views/components/assistant-staff.blade.php
@@ -1,10 +1,11 @@
 @unless(count($staff) == 0)
-    <div class="w-full mt-5 border-t-1 border-base-content pt-2">
-        <h2 class="text-2xl mb-2">{{ $positionTitle }}</h2>
+    <div class="divider my-3"></div>
+    <h2 class="text-base font-semibold mb-2">{{ $positionTitle }}</h2>
 
+    <div class="flex flex-col gap-1 pl-2">
         @foreach($staff as $staffMember)
             <a href="{{route('users.show', ['user' => $staffMember->user->id])}}"
-            class="text-lg pl-5"
+            class="text-lg hover:underline whitespace-nowrap"
             >
                 {{$staffMember->user->first_name.' '.$staffMember->user->last_name}} ({{$staffMember->user->rating->mapToString()}})
             </a>

--- a/resources/views/components/card-component.blade.php
+++ b/resources/views/components/card-component.blade.php
@@ -1,4 +1,4 @@
-<div class="card border-1 border-base-300 p-5">
+<div {{ $attributes->merge(['class' => 'card border-1 border-base-300 p-5']) }}>
     @unless(is_null($title ?? null))
         <h1 class="card-title text-lg font-bold leading-snug">{{ $title }}</h1>
     @endunless

--- a/resources/views/components/card-component.blade.php
+++ b/resources/views/components/card-component.blade.php
@@ -1,6 +1,6 @@
 <div class="card border-1 border-base-300 p-5">
     @unless(is_null($title ?? null))
-        <h1 class="card-title text-2xl">{{ $title }}</h1>
+        <h1 class="card-title text-lg font-bold leading-snug">{{ $title }}</h1>
     @endunless
 
     <div @class('card-body p-0')>

--- a/resources/views/components/login-button.blade.php
+++ b/resources/views/components/login-button.blade.php
@@ -1,3 +1,3 @@
-<a class='btn btn-info' href={{ route('auth.redirect') }}>
+<button type="button" class="btn btn-info" onclick="vatsim_login_modal.showModal()">
     Login With VATSIM
-</a>
+</button>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -25,10 +25,11 @@
                 <span>Controllers</span>
                 <x-dropdown-icon/>
             </div>
-            <ul tabindex="-1" class="dropdown-content text-base-content menu bg-base-100 rounded-box z-50 w-52 p-2 shadow-sm">
+            <ul tabindex="-1" class="dropdown-content text-base-content menu bg-base-100 rounded-box z-50 w-56 p-2 shadow-sm">
                 <li><a href="{{ route('visit.index') }}">Visit vZJX</a></li>
                 <li><a href="{{ route('roster.index') }}">Roster</a></li>
                 <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
+                <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
             </ul>
         </div>
 
@@ -94,6 +95,7 @@
             <li><a href="{{ route('visit.index') }}">Visit vZJX</a></li>
             <li><a href="{{ route('roster.index') }}">Roster</a></li>
             <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
+            <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
 
             @hasrole('staff')
                 <li class="menu-title text-xs uppercase tracking-wide pt-2">Facility Admin</li>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -35,6 +35,8 @@
                 <li><a href="{{ route('roster.index') }}">Roster</a></li>
                 <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
                 <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
+                <li><a href="https://docs.google.com/spreadsheets/d/1qCbtxKFFDbw-mgrPj1b_I71AI3aQXQN-ER0olcFCEtk/edit?gid=1029729582#gid=1029729582" target="_blank" rel="noopener">+1 Cheetus</a></li>
+                <li><a href="https://www.faa.gov/documentLibrary/media/Order/7110.65BB_Bsc_w_Chg_1_dtd_8-7-25.pdf" target="_blank" rel="noopener">ORDER JO 7110.65BB</a></li>
             </ul>
         </div>
 
@@ -117,6 +119,8 @@
             <li><a href="{{ route('roster.index') }}">Roster</a></li>
             <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
             <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
+            <li><a href="https://docs.google.com/spreadsheets/d/1qCbtxKFFDbw-mgrPj1b_I71AI3aQXQN-ER0olcFCEtk/edit?gid=1029729582#gid=1029729582" target="_blank" rel="noopener">+1 Cheetus</a></li>
+            <li><a href="https://www.faa.gov/documentLibrary/media/Order/7110.65BB_Bsc_w_Chg_1_dtd_8-7-25.pdf" target="_blank" rel="noopener">ORDER JO 7110.65BB</a></li>
 
             <li class="menu-title text-xs uppercase tracking-wide pt-2">Publications</li>
             <li><a href="{{ route('publications.index') }}">All Documents</a></li>
@@ -148,8 +152,37 @@
                 <li><a href="{{ route('users.show', [auth()->user()->id]) }}">{{ auth()->user()->first_name }} {{ auth()->user()->last_name }} - {{ auth()->user()->rating->mapToString() }}</a></li>
                 <li><a href="{{ route('auth.logout') }}" class="text-error">Logout</a></li>
             @else
-                <li><a href="{{ route('auth.redirect') }}">Login With VATSIM</a></li>
+                <li><a href="#" onclick="event.preventDefault(); vatsim_login_modal.showModal()">Login With VATSIM</a></li>
             @endif
         </ul>
     </div>
 </div>
+
+{{-- VATSIM login confirmation modal (shared by desktop & mobile triggers) --}}
+@guest
+<dialog id="vatsim_login_modal" class="modal" x-data="{ confirmed: false }" @close="confirmed = false">
+    <div class="modal-box text-base-content">
+        <h3 class="font-bold text-lg">Confirm Sign In</h3>
+        <p class="py-4 text-sm">
+            The information contained on all pages of this website is to be used for flight simulation purposes only on the VATSIM network. It is not intended nor should it be used for real world navigation. This site is not affiliated with the FAA, NATCA, the actual Jacksonville ARTCC, or any governing aviation body. All content contained herein is approved only for use on the VATSIM network.
+        </p>
+        <label class="flex items-start cursor-pointer gap-3 mt-2">
+            <input type="checkbox" x-model="confirmed" class="checkbox checkbox-primary mt-0.5 shrink-0" />
+            <span class="text-sm leading-snug">I understand that <strong>we are a virtual organization</strong> and do NOT have any affiliation with the FAA, ZJX, or any government agency.</span>
+        </label>
+        <div class="modal-action">
+            <form method="dialog">
+                <button class="btn btn-error">Cancel</button>
+            </form>
+            <a x-bind:href="confirmed ? '{{ route('auth.redirect') }}' : '#'"
+               x-bind:class="confirmed ? 'btn btn-success' : 'btn btn-success btn-disabled'"
+               x-bind:aria-disabled="!confirmed">
+                Continue with Login
+            </a>
+        </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+    </form>
+</dialog>
+@endguest

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -35,8 +35,6 @@
                 <li><a href="{{ route('roster.index') }}">Roster</a></li>
                 <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
                 <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
-                <li><a href="https://docs.google.com/spreadsheets/d/1qCbtxKFFDbw-mgrPj1b_I71AI3aQXQN-ER0olcFCEtk/edit?gid=1029729582#gid=1029729582" target="_blank" rel="noopener">+1 Cheetus</a></li>
-                <li><a href="https://www.faa.gov/documentLibrary/media/Order/7110.65BB_Bsc_w_Chg_1_dtd_8-7-25.pdf" target="_blank" rel="noopener">ORDER JO 7110.65BB</a></li>
             </ul>
         </div>
 
@@ -119,8 +117,6 @@
             <li><a href="{{ route('roster.index') }}">Roster</a></li>
             <li><a href="{{ route('staff.index') }}">Facility Staff</a></li>
             <li><a href="{{ route('statistics.index') }}">Statistics</a></li>
-            <li><a href="https://docs.google.com/spreadsheets/d/1qCbtxKFFDbw-mgrPj1b_I71AI3aQXQN-ER0olcFCEtk/edit?gid=1029729582#gid=1029729582" target="_blank" rel="noopener">+1 Cheetus</a></li>
-            <li><a href="https://www.faa.gov/documentLibrary/media/Order/7110.65BB_Bsc_w_Chg_1_dtd_8-7-25.pdf" target="_blank" rel="noopener">ORDER JO 7110.65BB</a></li>
 
             <li class="menu-title text-xs uppercase tracking-wide pt-2">Publications</li>
             <li><a href="{{ route('publications.index') }}">All Documents</a></li>
@@ -174,11 +170,12 @@
             <form method="dialog">
                 <button class="btn btn-error">Cancel</button>
             </form>
-            <a x-bind:href="confirmed ? '{{ route('auth.redirect') }}' : '#'"
-               x-bind:class="confirmed ? 'btn btn-success' : 'btn btn-success btn-disabled'"
-               x-bind:aria-disabled="!confirmed">
+            <button type="button"
+                    x-bind:disabled="!confirmed"
+                    x-bind:class="confirmed ? 'btn btn-success' : 'btn btn-success btn-disabled'"
+                    @click="window.location.href='{{ route('auth.redirect') }}'">
                 Continue with Login
-            </a>
+            </button>
         </div>
     </div>
     <form method="dialog" class="modal-backdrop">

--- a/resources/views/components/staff-card.blade.php
+++ b/resources/views/components/staff-card.blade.php
@@ -1,4 +1,4 @@
-<x-card-component :title="$position">
+<x-card-component :title="$position" class="h-full">
     <div class="flex flex-col h-full content-stretch">
         @unless(is_null($staff))
             <a href="{{route('users.show', ['user' => $staff->user->id])}}" class="text-2xl mb-1">{{ $staff->user->first_name.' '.$staff->user->last_name }} ({{$staff->user->rating->mapToString()}})</a>
@@ -8,8 +8,9 @@
         @endunless
 
         <p class="text-lg">{{$description}}</p>
-        <p class="text-lg mt-5"><strong>Reports to:</strong> {{$reportsTo}}</p>
 
         {{$slot}}
+
+        <p class="text-lg mt-auto pt-5"><strong>Reports to:</strong> {{$reportsTo}}</p>
     </div>
 </x-card-component>

--- a/resources/views/components/staff-card.blade.php
+++ b/resources/views/components/staff-card.blade.php
@@ -2,7 +2,7 @@
     <div class="flex flex-col h-full content-stretch">
         @unless(is_null($staff))
             <a href="{{route('users.show', ['user' => $staff->user->id])}}" class="text-2xl mb-1">{{ $staff->user->first_name.' '.$staff->user->last_name }} ({{$staff->user->rating->mapToString()}})</a>
-            <a href="mailto:{{ strtolower($staff->title_short) }}@zjxartcc.org" class="text-base text-base-content/80 hover:underline mb-5">{{ strtolower($staff->title_short) }}@zjxartcc.org</a>
+            <a href="mailto:zjx-{{ strtolower($staff->title_short) }}@vatusa.net" class="text-base text-base-content/80 hover:underline mb-5">zjx-{{ strtolower($staff->title_short) }}@vatusa.net</a>
         @else
             <h2 class="text-2xl mb-5">Vacant</h2>
         @endunless

--- a/resources/views/components/staff-card.blade.php
+++ b/resources/views/components/staff-card.blade.php
@@ -1,7 +1,8 @@
 <x-card-component :title="$position">
     <div class="flex flex-col h-full content-stretch">
         @unless(is_null($staff))
-            <a href="{{route('users.show', ['user' => $staff->user->id])}}" class="text-2xl mb-5">{{ $staff->user->first_name.' '.$staff->user->last_name }} ({{$staff->user->rating->mapToString()}})</a>
+            <a href="{{route('users.show', ['user' => $staff->user->id])}}" class="text-2xl mb-1">{{ $staff->user->first_name.' '.$staff->user->last_name }} ({{$staff->user->rating->mapToString()}})</a>
+            <a href="mailto:{{ strtolower($staff->title_short) }}@zjxartcc.org" class="text-base text-base-content/80 hover:underline mb-5">{{ strtolower($staff->title_short) }}@zjxartcc.org</a>
         @else
             <h2 class="text-2xl mb-5">Vacant</h2>
         @endunless

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -23,7 +23,7 @@
             @vite(['resources/css/app.css', 'resources/js/app.js'])
         @endif
     </head>
-    <body class='flex flex-col min-h-screen w-full overflow-x-hidden' data-theme='light'>
+    <body class='flex flex-col min-h-screen w-full overflow-x-hidden font-sans' data-theme='light'>
         <x-navbar/>
 
         @yield('secondary-navbar')
@@ -54,7 +54,12 @@
 
         @yield('body-nopad')
 
-        <h1 class='font-bold text-2xl ml-5 mt-5'>@yield('title')</h1>
+        <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 ml-5 mt-5">
+            <h1 class='font-bold text-2xl'>@yield('title')</h1>
+            @hasSection('title-extra')
+                @yield('title-extra')
+            @endif
+        </div>
 
         <div class="p-5 flex-1">
             @yield('body')

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -32,7 +32,7 @@
                 
             </div>
 
-            <div class='w-full max-w-4xl mx-auto bg-base-100 border-base-300 border-1 p-3 sm:p-4'>
+            <div class='w-full max-w-4xl mx-auto bg-base-100 border-base-300 border p-3 sm:p-4'>
                 @yield('profile-content')
             </div>
 @endsection

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -8,58 +8,58 @@
         {{-- All Senior & Department Head Staff in one 6-card grid --}}
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
             <x-staff-card
-                position="Air Traffic Manager"
+                position="Air Traffic Manager (ATM)"
                 description="The Air Traffic Manager oversees day-to-day operations and collaborates with all staff members of the ARTCC."
                 :staff="$atm"
                 reportsTo="VATUSA"
             />
 
             <x-staff-card
-                position="Deputy Air Traffic Manager"
+                position="Deputy Air Traffic Manager (DATM)"
                 description="The Deputy Air Traffic Manager assists the Air Traffic Manager in overseeing the ARTCC. The Deputy Air Traffic Manager also oversees the Web, Events, and Facilities Department and assists as needed."
                 :staff="$datm"
                 reportsTo="Air Traffic Manager"
             />
 
             <x-staff-card
-                position="Training Administrator"
+                position="Training Administrator (TA)"
                 description="The Training Administrator is responsible for overseeing the training department of the ARTCC."
                 :staff="$ta"
                 reportsTo="Air Traffic Manager"
             />
 
             <x-staff-card
-                position="Events Coordinator"
+                position="Events Coordinator (EC)"
                 description="The Events Coordinator manages the planning and execution of events related to vZJX or our neighbors."
                 :staff="$ec"
                 reportsTo="Deputy Air Traffic Manager"
             >
                 <x-assistant-staff
-                    positionTitle="Assistant Events Coordinators"
+                    positionTitle="Assistant Events Coordinators (AECs)"
                     :staff="$eventsTeam"
                 />
             </x-staff-card>
 
             <x-staff-card
-                position="Facility Engineer"
+                position="Facility Engineer (FE)"
                 description="The Facility Engineer is responsible for managing all data related to the VATSIM network, such as standard operating procedures and radar maps."
                 :staff="$fe"
                 reportsTo="Deputy Air Traffic Manager"
             >
                 <x-assistant-staff
-                    positionTitle="Assistant Facility Engineers"
+                    positionTitle="Assistant Facility Engineers (AFEs)"
                     :staff="$facilitiesTeam"
                 />
             </x-staff-card>
 
             <x-staff-card
-                position="Webmaster"
+                position="Webmaster (WM)"
                 description="The Webmaster handles all management of data systems in the vZJX network, including the website, relational databases, email systems, and more."
                 :staff="$wm"
                 reportsTo="Deputy Air Traffic Manager"
             >
                 <x-assistant-staff
-                    positionTitle="Assistant Webmasters"
+                    positionTitle="Assistant Webmasters (AWMs)"
                     :staff="$webTeam"
                 />
             </x-staff-card>

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -1,0 +1,340 @@
+@extends('layouts.main')
+
+@section('title', 'Controller Statistics')
+
+@section('body')
+
+    @php
+        $periodLabel = $month === 0
+            ? $year . ' Statistics'
+            : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') . ' Statistics';
+        $facilityLabels = [2 => 'DEL', 3 => 'GND', 4 => 'TWR', 5 => 'TRC', 6 => 'CTR'];
+        $ctrlListJs  = $controllers->map(fn($c) => ['id' => $c->id, 'label' => $c->first_name . ' ' . $c->last_name . ' (' . $c->rating->mapToString() . ')']);
+        $ctrlMatch   = $cid ? $controllers->firstWhere('id', $cid) : null;
+        $ctrlInitLbl = $ctrlMatch ? ($ctrlMatch->first_name . ' ' . $ctrlMatch->last_name . ' (' . $ctrlMatch->rating->mapToString() . ')') : 'Controller';
+        $ctrlInitId  = $cid ?? '';
+    @endphp
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('controllerPicker', () => ({
+                open: false,
+                search: '',
+                selected: { id: @json($ctrlInitId), label: @json($ctrlInitLbl) },
+                controllers: @json($ctrlListJs),
+                get filtered() {
+                    return this.search === ''
+                        ? this.controllers
+                        : this.controllers.filter(c => c.label.toLowerCase().includes(this.search.toLowerCase()));
+                },
+                choose(c) { this.selected = c; this.open = false; this.search = ''; }
+            }));
+        });
+    </script>
+
+    {{-- Individual controller view --}}
+    @if($selectedController)
+
+        <div class="space-y-6">
+            <div>
+                <h2 class="text-2xl sm:text-3xl font-bold">
+                    {{ $selectedController->name }} ({{ $selectedController->rating->mapToString() }})
+                </h2>
+                <p class="text-sm text-base-content/60 mt-1">{{ $periodLabel }} &mdash; Stats can take up to 24 hours to update.</p>
+            </div>
+
+            @if($controllerMonthly->isEmpty())
+                <p class="text-base">No activity recorded for {{ $selectedController->first_name }} in {{ $year }}.</p>
+            @else
+                <x-card-component title="{{ $year }} Monthly Breakdown">
+                    <div class="flex flex-wrap gap-x-8 gap-y-3 border-b border-base-300 pb-4 mb-4 mt-3">
+                        @foreach([
+                            ['label' => 'Delivery', 'value' => $controllerMonthly->sum('delivery_hours')],
+                            ['label' => 'Ground',   'value' => $controllerMonthly->sum('ground_hours')],
+                            ['label' => 'Tower',    'value' => $controllerMonthly->sum('tower_hours')],
+                            ['label' => 'TRACON',   'value' => $controllerMonthly->sum('approach_hours')],
+                            ['label' => 'Center',   'value' => $controllerMonthly->sum('center_hours')],
+                            ['label' => 'Total',    'value' => $controllerMonthly->sum(fn($r) => $r->totalHours())],
+                        ] as $item)
+                            <div>
+                                <p class="text-xs text-base-content/60 mb-1">{{ $item['label'] }}</p>
+                                <p class="text-lg font-bold">{{ number_format($item['value'], 1) }}h</p>
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="table table-zebra table-sm sm:table-md w-full border border-base-300">
+                            <thead>
+                                <tr>
+                                    <th class="whitespace-nowrap">Month</th>
+                                    <th class="text-right whitespace-nowrap hidden sm:table-cell">Delivery</th>
+                                    <th class="text-right whitespace-nowrap hidden sm:table-cell">Ground</th>
+                                    <th class="text-right whitespace-nowrap hidden sm:table-cell">Tower</th>
+                                    <th class="text-right whitespace-nowrap hidden sm:table-cell">TRACON</th>
+                                    <th class="text-right whitespace-nowrap hidden sm:table-cell">Center</th>
+                                    <th class="text-right whitespace-nowrap">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($controllerMonthly as $row)
+                                    <tr>
+                                        <td class="whitespace-nowrap">{{ \Illuminate\Support\Carbon::create($row->year, $row->month, 1)->format('F') }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $row->delivery_hours > 0 ? number_format($row->delivery_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $row->ground_hours > 0 ? number_format($row->ground_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $row->tower_hours > 0 ? number_format($row->tower_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $row->approach_hours > 0 ? number_format($row->approach_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $row->center_hours > 0 ? number_format($row->center_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right font-bold">{{ number_format($row->totalHours(), 1) }}h</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </x-card-component>
+
+                @if($month !== 0 && $controllerSessions->isNotEmpty())
+                    <x-card-component title="{{ \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') }} Sessions">
+                        <div class="overflow-x-auto mt-3">
+                            <table class="table table-zebra table-sm sm:table-md w-full border border-base-300">
+                                <thead>
+                                    <tr>
+                                        <th class="whitespace-nowrap">Position</th>
+                                        <th class="whitespace-nowrap">Type</th>
+                                        <th class="whitespace-nowrap">Date</th>
+                                        <th class="text-right whitespace-nowrap">Duration</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($controllerSessions as $session)
+                                        <tr>
+                                            <td class="font-mono whitespace-nowrap">{{ $session->callsign }}</td>
+                                            <td>{{ $facilityLabels[$session->facility_level] ?? '—' }}</td>
+                                            <td class="whitespace-nowrap">{{ $session->start->format('d M Y') }}</td>
+                                            <td class="text-right">{{ number_format($session->durationHours(), 2) }}h</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </x-card-component>
+                @endif
+            @endif
+
+            {{-- Filter --}}
+            <form method="GET" action="{{ route('statistics.index') }}">
+                <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
+                    <div class="flex flex-col gap-1 w-full sm:w-auto">
+                        <label class="text-sm">Month</label>
+                        <select name="month" class="select w-full sm:w-auto">
+                            <option value="all" @selected($month === 0)>All Months</option>
+                            @foreach(range(1, 12) as $m)
+                                <option value="{{ $m }}" @selected($m == $month)>
+                                    {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="flex flex-col gap-1 w-full sm:w-auto">
+                        <label class="text-sm">Year</label>
+                        <select name="year" class="select w-full sm:w-auto">
+                            @foreach($years as $y)
+                                <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="flex flex-col gap-1 w-full sm:w-44" x-data="controllerPicker" @click.outside="open = false">
+                        <label class="text-sm">Controller</label>
+                        <input type="hidden" name="cid" :value="selected.id">
+                        <div class="relative">
+                            <button type="button" @click="open = !open"
+                                class="select w-full text-left flex items-center justify-between">
+                                <span x-text="selected.label" class="truncate"></span>
+                            </button>
+                            <div x-show="open" x-cloak
+                                class="absolute z-50 mt-1 min-w-full w-max bg-base-200 border border-base-300 rounded-lg shadow-lg">
+                                <div class="p-2">
+                                    <input type="text" x-model="search" placeholder="Search..."
+                                        class="input input-sm w-full" @click.stop>
+                                </div>
+                                <ul class="max-h-52 overflow-y-auto">
+                                    <li>
+                                        <button type="button" @click="choose({ id: '', label: 'Controller' })"
+                                            class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                            :class="selected.id === '' ? 'font-semibold' : ''">All Controllers</button>
+                                    </li>
+                                    <template x-for="c in filtered" :key="c.id">
+                                        <li>
+                                            <button type="button" @click="choose(c)"
+                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                :class="selected.id == c.id ? 'font-semibold' : ''"
+                                                x-text="c.label"></button>
+                                        </li>
+                                    </template>
+                                    <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
+                </div>
+            </form>
+        </div>
+
+    {{-- Leaderboard view --}}
+    @else
+
+        <div class="space-y-6">
+            <div>
+                <h2 class="text-2xl sm:text-3xl font-bold">{{ $periodLabel }}</h2>
+                <p class="text-base-content/60 mt-1">Stats can take up to 24 hours to update.</p>
+            </div>
+
+            @if($stats->isEmpty())
+                <p class="text-base">No controller activity recorded for this period.</p>
+            @else
+
+                {{-- All-Time Hours --}}
+                <x-card-component title="All-Time Hours">
+                    <div class="mt-3">
+                        <p class="text-xs text-base-content/60 mb-1">Total ARTCC Hours{{ $allTimeSince ? ' since ' . $allTimeSince : '' }}</p>
+                        <p class="text-3xl font-bold">{{ number_format($allTimeHours, 1) }}h</p>
+                    </div>
+                </x-card-component>
+
+                {{-- Facility Totals --}}
+                <x-card-component title="Facility Totals - {{ $month === 0 ? $year : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') }}">
+                    <div class="flex flex-wrap gap-x-8 gap-y-3 mt-3">
+                        @foreach([
+                            ['label' => 'Delivery', 'value' => $totals['delivery']],
+                            ['label' => 'Ground',   'value' => $totals['ground']],
+                            ['label' => 'Tower',    'value' => $totals['tower']],
+                            ['label' => 'TRACON',   'value' => $totals['approach']],
+                            ['label' => 'Center',   'value' => $totals['center']],
+                            ['label' => 'Total',    'value' => $totals['total']],
+                        ] as $item)
+                            <div>
+                                <p class="text-xs text-base-content/60 mb-1">{{ $item['label'] }}</p>
+                                <p class="text-lg font-bold">{{ number_format($item['value'], 1) }}h</p>
+                            </div>
+                        @endforeach
+
+                    </div>
+                </x-card-component>
+
+                {{-- Top 3 --}}
+                @if($stats->count() >= 1)
+                    <div>
+                        <p class="text-lg font-semibold text-base-content/60 mb-2">Top Controllers</p>
+                        <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-base-300 border border-base-300 rounded-lg overflow-hidden">
+                            @foreach($stats->take(3) as $idx => $stat)
+                                <a href="{{ route('users.show', ['user' => $stat->user->id]) }}"
+                                   class="no-underline text-base-content hover:bg-base-200 transition-colors p-6">
+                                    <p class="text-xl font-bold leading-snug mb-4">#{{ $idx + 1 }} &mdash; {{ $stat->user->name }} <span class="font-normal text-base-content/60">({{ $stat->user->rating->mapToString() }})</span></p>
+                                    <p class="text-3xl font-bold">{{ number_format($stat->totalHours(), 1) }}h</p>
+                                </a>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                {{-- Filter above All Controllers --}}
+                <form method="GET" action="{{ route('statistics.index') }}">
+                    <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
+                        <div class="flex flex-col gap-1 w-full sm:w-auto">
+                            <label class="text-sm">Month</label>
+                            <select name="month" class="select w-full sm:w-auto">
+                                <option value="all" @selected($month === 0)>All Months</option>
+                                @foreach(range(1, 12) as $m)
+                                    <option value="{{ $m }}" @selected($m == $month)>
+                                        {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col gap-1 w-full sm:w-auto">
+                            <label class="text-sm">Year</label>
+                            <select name="year" class="select w-full sm:w-auto">
+                                @foreach($years as $y)
+                                    <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col gap-1 w-full sm:w-44" x-data="controllerPicker" @click.outside="open = false">
+                            <label class="text-sm">Controller</label>
+                            <input type="hidden" name="cid" :value="selected.id">
+                            <div class="relative">
+                                <button type="button" @click="open = !open"
+                                    class="select w-full text-left flex items-center justify-between">
+                                    <span x-text="selected.label" class="truncate"></span>
+                                </button>
+                                <div x-show="open" x-cloak
+                                    class="absolute z-50 mt-1 min-w-full w-max bg-base-200 border border-base-300 rounded-lg shadow-lg">
+                                    <div class="p-2">
+                                        <input type="text" x-model="search" placeholder="Search..."
+                                            class="input input-sm w-full" @click.stop>
+                                    </div>
+                                    <ul class="max-h-52 overflow-y-auto">
+                                        <li>
+                                            <button type="button" @click="choose({ id: '', label: 'Controller' })"
+                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                :class="selected.id === '' ? 'font-semibold' : ''">All Controllers</button>
+                                        </li>
+                                        <template x-for="c in filtered" :key="c.id">
+                                            <li>
+                                                <button type="button" @click="choose(c)"
+                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                    :class="selected.id == c.id ? 'font-semibold' : ''"
+                                                    x-text="c.label"></button>
+                                            </li>
+                                        </template>
+                                        <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
+                    </div>
+                </form>
+
+                {{-- Full leaderboard table --}}
+                <x-card-component title="All Controllers">
+                    <div class="overflow-x-auto mt-3">
+                        <table class="table table-zebra table-sm sm:table-md w-full border border-base-300">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Controller</th>
+                                    <th class="text-right hidden sm:table-cell whitespace-nowrap">Delivery</th>
+                                    <th class="text-right hidden sm:table-cell whitespace-nowrap">Ground</th>
+                                    <th class="text-right hidden sm:table-cell whitespace-nowrap">Tower</th>
+                                    <th class="text-right hidden sm:table-cell whitespace-nowrap">TRACON</th>
+                                    <th class="text-right hidden sm:table-cell whitespace-nowrap">Center</th>
+                                    <th class="text-right whitespace-nowrap">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($stats as $idx => $stat)
+                                    <tr>
+                                        <td class="text-base-content/60 text-sm">{{ $idx + 1 }}</td>
+                                        <td>
+                                            <a href="{{ route('users.show', ['user' => $stat->user->id]) }}"
+                                               class="font-medium hover:underline">{{ $stat->user->name }}</a>
+                                            <span class="text-xs text-base-content/60 ml-1">({{ $stat->user->rating->mapToString() }})</span>
+                                        </td>
+                                        <td class="text-right hidden sm:table-cell">{{ $stat->delivery_hours > 0 ? number_format($stat->delivery_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $stat->ground_hours > 0 ? number_format($stat->ground_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $stat->tower_hours > 0 ? number_format($stat->tower_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $stat->approach_hours > 0 ? number_format($stat->approach_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right hidden sm:table-cell">{{ $stat->center_hours > 0 ? number_format($stat->center_hours, 1).'h' : '—' }}</td>
+                                        <td class="text-right font-bold">{{ number_format($stat->totalHours(), 1) }}h</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </x-card-component>
+
+            @endif
+        </div>
+    @endif
+@endsection

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -5,28 +5,54 @@
 @section('body')
 
     @php
-        $periodLabel = $month === 0
-            ? $year . ' Statistics'
-            : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') . ' Statistics';
+        $periodLabel = $year === 0
+            ? ($month === 0 ? 'All-Time Statistics' : \Illuminate\Support\Carbon::create(null, $month)->format('F') . ' (All Years) Statistics')
+            : ($month === 0
+                ? $year . ' Statistics'
+                : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') . ' Statistics');
         $facilityLabels = [2 => 'DEL', 3 => 'GND', 4 => 'TWR', 5 => 'TRC', 6 => 'CTR'];
         $ctrlListJs  = $controllers->map(fn($c) => ['id' => $c->id, 'label' => $c->first_name . ' ' . $c->last_name . ' (' . $c->rating->mapToString() . ')']);
         $ctrlMatch   = $cid ? $controllers->firstWhere('id', $cid) : null;
-        $ctrlInitLbl = $ctrlMatch ? ($ctrlMatch->first_name . ' ' . $ctrlMatch->last_name . ' (' . $ctrlMatch->rating->mapToString() . ')') : 'Controller';
+        $ctrlInitLbl = $ctrlMatch ? ($ctrlMatch->first_name . ' ' . $ctrlMatch->last_name . ' (' . $ctrlMatch->rating->mapToString() . ')') : '';
         $ctrlInitId  = $cid ?? '';
     @endphp
     <script>
         document.addEventListener('alpine:init', () => {
             Alpine.data('controllerPicker', () => ({
                 open: false,
-                search: '',
-                selected: { id: @json($ctrlInitId), label: @json($ctrlInitLbl) },
+                query: @json($ctrlInitLbl),
+                selectedId: @json($ctrlInitId),
                 controllers: @json($ctrlListJs),
                 get filtered() {
-                    return this.search === ''
-                        ? this.controllers
-                        : this.controllers.filter(c => c.label.toLowerCase().includes(this.search.toLowerCase()));
+                    const sel = this.controllers.find(c => c.id == this.selectedId);
+                    if (!this.query || (sel && sel.label === this.query)) return this.controllers;
+                    const q = this.query.toLowerCase();
+                    return this.controllers.filter(c => c.label.toLowerCase().includes(q));
                 },
-                choose(c) { this.selected = c; this.open = false; this.search = ''; }
+                choose(c) {
+                    this.selectedId = c.id;
+                    this.query = c.label;
+                    this.open = false;
+                },
+                clearSelection() {
+                    this.selectedId = '';
+                    this.open = true;
+                },
+                onEnter(e) {
+                    const first = this.filtered[0];
+                    if (first) {
+                        this.choose(first);
+                        this.$nextTick(() => e.target.form.submit());
+                    }
+                },
+                handleSubmit(e) {
+                    if (this.query && !this.selectedId) {
+                        const first = this.filtered[0];
+                        if (first) { this.selectedId = first.id; this.query = first.label; }
+                    }
+                    if (!this.query) this.selectedId = '';
+                    this.$nextTick(() => e.target.submit());
+                },
             }));
         });
     </script>
@@ -42,10 +68,73 @@
                 <p class="text-sm text-base-content/60 mt-1">{{ $periodLabel }} &mdash; Stats can take up to 24 hours to update.</p>
             </div>
 
+            {{-- Filter --}}
+            <form method="GET" action="{{ route('statistics.index') }}" x-data="controllerPicker" @submit.prevent="handleSubmit($event)">
+                <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
+                    <div class="flex flex-col gap-1 w-full sm:w-auto">
+                        <label class="text-sm">Month</label>
+                        <select name="month" class="select w-full sm:w-auto">
+                            <option value="all" @selected($month === 0)>All Months</option>
+                            @foreach(range(1, 12) as $m)
+                                <option value="{{ $m }}" @selected($m == $month)>
+                                    {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="flex flex-col gap-1 w-full sm:w-auto">
+                        <label class="text-sm">Year</label>
+                        <select name="year" class="select w-full sm:w-auto">
+                            <option value="all" @selected($year === 0)>All Years</option>
+                            @foreach($years as $y)
+                                <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="flex flex-col gap-1 w-full sm:w-56 relative" @click.outside="open = false">
+                        <label class="text-sm">Controller</label>
+                        <input type="hidden" name="cid" :value="selectedId">
+                        <div class="relative">
+                            <input type="text" x-model="query"
+                                @focus="open = true"
+                                @input="clearSelection()"
+                                @keydown.escape="open = false"
+                                @keydown.enter.prevent="onEnter($event)"
+                                @keydown.arrow-down.prevent="open = true"
+                                placeholder="All Controllers"
+                                class="input w-full pr-8">
+                            <span class="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-base-content/40">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                            </span>
+                            <div x-show="open" x-cloak
+                                class="absolute z-50 top-full left-0 mt-1 w-full bg-base-200 border border-base-300 rounded-lg shadow-lg">
+                                <ul class="max-h-52 overflow-y-auto">
+                                    <li>
+                                        <button type="button" @click="choose({ id: '', label: '' })"
+                                            class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                            :class="selectedId === '' ? 'font-semibold' : ''">All Controllers</button>
+                                    </li>
+                                    <template x-for="c in filtered" :key="c.id">
+                                        <li>
+                                            <button type="button" @click="choose(c)"
+                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                :class="selectedId == c.id ? 'font-semibold' : ''"
+                                                x-text="c.label"></button>
+                                        </li>
+                                    </template>
+                                    <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
+                </div>
+            </form>
+
             @if($controllerMonthly->isEmpty())
-                <p class="text-base">No activity recorded for {{ $selectedController->first_name }} in {{ $year }}.</p>
+                <p class="text-base">No activity recorded for {{ $selectedController->first_name }}{{ $year === 0 ? '' : ' in ' . $year }}.</p>
             @else
-                <x-card-component title="{{ $year }} Monthly Breakdown">
+                <x-card-component title="{{ $year === 0 ? 'All-Time' : $year }} Monthly Breakdown">
                     <div class="flex flex-wrap gap-x-8 gap-y-3 border-b border-base-300 pb-4 mb-4 mt-3">
                         @foreach([
                             ['label' => 'Delivery', 'value' => $controllerMonthly->sum('delivery_hours')],
@@ -78,7 +167,7 @@
                             <tbody>
                                 @foreach($controllerMonthly as $row)
                                     <tr>
-                                        <td class="whitespace-nowrap">{{ \Illuminate\Support\Carbon::create($row->year, $row->month, 1)->format('F') }}</td>
+                                        <td class="whitespace-nowrap">{{ \Illuminate\Support\Carbon::create($row->year, $row->month, 1)->format($year === 0 ? 'M Y' : 'F') }}</td>
                                         <td class="text-right hidden sm:table-cell">{{ $row->delivery_hours > 0 ? number_format($row->delivery_hours, 1).'h' : '—' }}</td>
                                         <td class="text-right hidden sm:table-cell">{{ $row->ground_hours > 0 ? number_format($row->ground_hours, 1).'h' : '—' }}</td>
                                         <td class="text-right hidden sm:table-cell">{{ $row->tower_hours > 0 ? number_format($row->tower_hours, 1).'h' : '—' }}</td>
@@ -119,65 +208,6 @@
                     </x-card-component>
                 @endif
             @endif
-
-            {{-- Filter --}}
-            <form method="GET" action="{{ route('statistics.index') }}">
-                <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
-                    <div class="flex flex-col gap-1 w-full sm:w-auto">
-                        <label class="text-sm">Month</label>
-                        <select name="month" class="select w-full sm:w-auto">
-                            <option value="all" @selected($month === 0)>All Months</option>
-                            @foreach(range(1, 12) as $m)
-                                <option value="{{ $m }}" @selected($m == $month)>
-                                    {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
-                                </option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="flex flex-col gap-1 w-full sm:w-auto">
-                        <label class="text-sm">Year</label>
-                        <select name="year" class="select w-full sm:w-auto">
-                            @foreach($years as $y)
-                                <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="flex flex-col gap-1 w-full sm:w-44" x-data="controllerPicker" @click.outside="open = false">
-                        <label class="text-sm">Controller</label>
-                        <input type="hidden" name="cid" :value="selected.id">
-                        <div class="relative">
-                            <button type="button" @click="open = !open"
-                                class="select w-full text-left flex items-center justify-between">
-                                <span x-text="selected.label" class="truncate"></span>
-                            </button>
-                            <div x-show="open" x-cloak
-                                class="absolute z-50 mt-1 min-w-full w-max bg-base-200 border border-base-300 rounded-lg shadow-lg">
-                                <div class="p-2">
-                                    <input type="text" x-model="search" placeholder="Search..."
-                                        class="input input-sm w-full" @click.stop>
-                                </div>
-                                <ul class="max-h-52 overflow-y-auto">
-                                    <li>
-                                        <button type="button" @click="choose({ id: '', label: 'Controller' })"
-                                            class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
-                                            :class="selected.id === '' ? 'font-semibold' : ''">All Controllers</button>
-                                    </li>
-                                    <template x-for="c in filtered" :key="c.id">
-                                        <li>
-                                            <button type="button" @click="choose(c)"
-                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
-                                                :class="selected.id == c.id ? 'font-semibold' : ''"
-                                                x-text="c.label"></button>
-                                        </li>
-                                    </template>
-                                    <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                    <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
-                </div>
-            </form>
         </div>
 
     {{-- Leaderboard view --}}
@@ -188,6 +218,69 @@
                 <h2 class="text-2xl sm:text-3xl font-bold">{{ $periodLabel }}</h2>
                 <p class="text-base-content/60 mt-1">Stats can take up to 24 hours to update.</p>
             </div>
+
+            {{-- Filter --}}
+            <form method="GET" action="{{ route('statistics.index') }}" x-data="controllerPicker" @submit.prevent="handleSubmit($event)">
+                    <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
+                        <div class="flex flex-col gap-1 w-full sm:w-auto">
+                            <label class="text-sm">Month</label>
+                            <select name="month" class="select w-full sm:w-auto">
+                                <option value="all" @selected($month === 0)>All Months</option>
+                                @foreach(range(1, 12) as $m)
+                                    <option value="{{ $m }}" @selected($m == $month)>
+                                        {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col gap-1 w-full sm:w-auto">
+                            <label class="text-sm">Year</label>
+                            <select name="year" class="select w-full sm:w-auto">
+                                <option value="all" @selected($year === 0)>All Years</option>
+                                @foreach($years as $y)
+                                    <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col gap-1 w-full sm:w-56 relative" @click.outside="open = false">
+                            <label class="text-sm">Controller</label>
+                            <input type="hidden" name="cid" :value="selectedId">
+                            <div class="relative">
+                                <input type="text" x-model="query"
+                                    @focus="open = true"
+                                    @input="clearSelection()"
+                                    @keydown.escape="open = false"
+                                    @keydown.enter.prevent="onEnter($event)"
+                                    @keydown.arrow-down.prevent="open = true"
+                                    placeholder="All Controllers"
+                                    class="input w-full pr-8">
+                                <span class="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-base-content/40">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                                </span>
+                                <div x-show="open" x-cloak
+                                    class="absolute z-50 top-full left-0 mt-1 w-full bg-base-200 border border-base-300 rounded-lg shadow-lg">
+                                    <ul class="max-h-52 overflow-y-auto">
+                                        <li>
+                                            <button type="button" @click="choose({ id: '', label: '' })"
+                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                :class="selectedId === '' ? 'font-semibold' : ''">All Controllers</button>
+                                        </li>
+                                        <template x-for="c in filtered" :key="c.id">
+                                            <li>
+                                                <button type="button" @click="choose(c)"
+                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                                    :class="selectedId == c.id ? 'font-semibold' : ''"
+                                                    x-text="c.label"></button>
+                                            </li>
+                                        </template>
+                                        <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
+                    </div>
+                </form>
 
             @if($stats->isEmpty())
                 <p class="text-base">No controller activity recorded for this period.</p>
@@ -202,7 +295,7 @@
                 </x-card-component>
 
                 {{-- Facility Totals --}}
-                <x-card-component title="Facility Totals - {{ $month === 0 ? $year : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y') }}">
+                <x-card-component title="Facility Totals - {{ $year === 0 ? ($month === 0 ? 'All Time' : \Illuminate\Support\Carbon::create(null, $month)->format('F') . ' (All Years)') : ($month === 0 ? $year : \Illuminate\Support\Carbon::create($year, $month, 1)->format('F Y')) }}">
                     <div class="flex flex-wrap gap-x-8 gap-y-3 mt-3">
                         @foreach([
                             ['label' => 'Delivery', 'value' => $totals['delivery']],
@@ -236,65 +329,6 @@
                         </div>
                     </div>
                 @endif
-
-                {{-- Filter above All Controllers --}}
-                <form method="GET" action="{{ route('statistics.index') }}">
-                    <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:items-end">
-                        <div class="flex flex-col gap-1 w-full sm:w-auto">
-                            <label class="text-sm">Month</label>
-                            <select name="month" class="select w-full sm:w-auto">
-                                <option value="all" @selected($month === 0)>All Months</option>
-                                @foreach(range(1, 12) as $m)
-                                    <option value="{{ $m }}" @selected($m == $month)>
-                                        {{ \Illuminate\Support\Carbon::create(null, $m)->format('F') }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="flex flex-col gap-1 w-full sm:w-auto">
-                            <label class="text-sm">Year</label>
-                            <select name="year" class="select w-full sm:w-auto">
-                                @foreach($years as $y)
-                                    <option value="{{ $y }}" @selected($y == $year)>{{ $y }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="flex flex-col gap-1 w-full sm:w-44" x-data="controllerPicker" @click.outside="open = false">
-                            <label class="text-sm">Controller</label>
-                            <input type="hidden" name="cid" :value="selected.id">
-                            <div class="relative">
-                                <button type="button" @click="open = !open"
-                                    class="select w-full text-left flex items-center justify-between">
-                                    <span x-text="selected.label" class="truncate"></span>
-                                </button>
-                                <div x-show="open" x-cloak
-                                    class="absolute z-50 mt-1 min-w-full w-max bg-base-200 border border-base-300 rounded-lg shadow-lg">
-                                    <div class="p-2">
-                                        <input type="text" x-model="search" placeholder="Search..."
-                                            class="input input-sm w-full" @click.stop>
-                                    </div>
-                                    <ul class="max-h-52 overflow-y-auto">
-                                        <li>
-                                            <button type="button" @click="choose({ id: '', label: 'Controller' })"
-                                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
-                                                :class="selected.id === '' ? 'font-semibold' : ''">All Controllers</button>
-                                        </li>
-                                        <template x-for="c in filtered" :key="c.id">
-                                            <li>
-                                                <button type="button" @click="choose(c)"
-                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
-                                                    :class="selected.id == c.id ? 'font-semibold' : ''"
-                                                    x-text="c.label"></button>
-                                            </li>
-                                        </template>
-                                        <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" class="btn btn-primary w-full sm:w-auto">Search</button>
-                    </div>
-                </form>
 
                 {{-- Full leaderboard table --}}
                 <x-card-component title="All Controllers">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -5,26 +5,54 @@
     <x-card-component title='General Information'>
         <x-user-data :user="$user"/>
     </x-card-component>
-    
+
     <x-card-component title='Statistics'>
-        <div class='flex flex-row justify-evenly border-b-1 gap-2 py-2'>
-            <x-profile-statistics-time-label
-                label='Total Time Online'
-                :time-interval='new DateInterval("PT300H")'/>
-
-            <x-profile-statistics-time-label
-                label='This Month'
-                :time-interval='new DateInterval("PT20H25M")'/>
-
-            <x-profile-statistics-time-label
-                label='This Year'
-                :time-interval='new DateInterval("PT112H35M")'/>
+        <div class="grid grid-cols-3 gap-4 border-b border-base-300 pb-4 mb-4 mt-2">
+            <div class="text-center">
+                <p class="text-xs text-base-content/60 mb-1">Total Hours</p>
+                <p class="text-xl sm:text-2xl font-bold">{{ number_format($totalHours, 1) }}h</p>
+            </div>
+            <div class="text-center">
+                <p class="text-xs text-base-content/60 mb-1">This Year</p>
+                <p class="text-xl sm:text-2xl font-bold">{{ number_format($yearHours, 1) }}h</p>
+            </div>
+            <div class="text-center">
+                <p class="text-xs text-base-content/60 mb-1">This Month</p>
+                <p class="text-xl sm:text-2xl font-bold">{{ number_format($monthHours, 1) }}h</p>
+            </div>
         </div>
 
-        <div class='mt-2'>
-            <h1 class='text-xl'>Last 10 Sessions</h1>
-        </div>
+        <p class="text-base font-semibold text-base-content/60 mb-3">Last 10 Sessions</p>
+
+        @if($recentSessions->isEmpty())
+            <p class='text-base'>No sessions recorded yet.</p>
+        @else
+            @php
+                $facilityLabels = [2 => 'DEL', 3 => 'GND', 4 => 'TWR', 5 => 'TRC', 6 => 'CTR'];
+            @endphp
+            <div class='overflow-x-auto'>
+                <table class='table table-zebra table-sm sm:table-md w-full border border-base-300'>
+                    <thead>
+                        <tr>
+                            <th class="whitespace-nowrap">Position</th>
+                            <th class="whitespace-nowrap">Type</th>
+                            <th class="whitespace-nowrap">Date</th>
+                            <th class="text-right whitespace-nowrap">Duration</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($recentSessions as $session)
+                            <tr>
+                                <td class="font-mono whitespace-nowrap">{{ $session->callsign }}</td>
+                                <td>{{ $facilityLabels[$session->facility_level] ?? '—' }}</td>
+                                <td class="whitespace-nowrap">{{ $session->start->format('d M Y') }}</td>
+                                <td class="text-right">{{ number_format($session->durationHours(), 2) }}h</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
     </x-card-component>
 </div>
-    
 @endsection

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Jobs\SyncRoster;
+use App\Jobs\SyncStatsimSessions;
 use App\Jobs\UpdateOnlineControllers;
 use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 
@@ -13,3 +15,10 @@ Artisan::command('inspire', function () {
 Schedule::job(new SyncRoster())->everyTwoHours();
 
 Schedule::job(new UpdateOnlineControllers())->everyMinute();
+
+Schedule::call(function () {
+    $now = Carbon::now();
+    SyncStatsimSessions::dispatch($now->year, $now->month);
+    $prev = $now->copy()->subMonthNoOverflow();
+    SyncStatsimSessions::dispatch($prev->year, $prev->month);
+})->dailyAt('04:00');

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,6 +97,10 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
     # Facilities Dept.
     Route::middleware('permission:manage statistics prefixes')->group(function() {
         Route::resource('statistics-prefixes', StatisticsPrefixesController::class);
+    });
+
+    # Senior Staff / Web Team
+    Route::middleware('role:admin')->group(function() {
         Route::post('statistics/sync', [StatisticsController::class, 'sync'])->name('statistics.sync');
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Auth\VatsimOauthController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\RosterController;
 use App\Http\Controllers\StaffController;
+use App\Http\Controllers\StatisticsController;
 use App\Http\Controllers\Training\SoloCertController;
 use App\Http\Controllers\Training\TrainingAssignmentController;
 use App\Http\Controllers\Training\TrainingTicketController;
@@ -60,6 +61,9 @@ Route::prefix('users/{user}')->group(function() {
 
 # Staff Directory
 Route::get('/staff', [StaffController::class, 'index'])->name('staff.index');
+
+# Controller Statistics
+Route::get('controllers/statistics', [StatisticsController::class, 'index'])->name('statistics.index');
 
 # Training Assignment Creation; TODO: make store
 Route::post('training-assignment/create', [TrainingAssignmentController::class, 'create'])->middleware('auth')->name('training-assignment.create');


### PR DESCRIPTION
## What's included

- **StatsSim sync job** (`SyncStatsimSessions`) — pulls ATC session data from the StatsSim API for a given month, filters to rostered controllers and recognised facility prefixes, and upserts into `controller_sessions`. Recomputes per-user monthly totals into `controller_monthly_stats` after each sync.
- **Scheduled sync** — runs daily at 04:00, syncing both the current and previous month to catch late-arriving data.
- **Artisan command** — `php artisan statsim:sync {year} {month}` for manual/backfill runs.
- **Statistics page** (`/controllers/statistics`) — leaderboard view with facility breakdowns and a searchable controller picker. Drills down to a per-controller yearly table and individual session log.
- **User profile stats** — Total, year-to-date, and current-month hours plus last 10 sessions now shown on the profile page, sourced from the synced data.
- **Database migrations** — `controller_sessions` and `controller_monthly_stats` tables.

## Setup required

Add the following to your `.env`:

```
STATS_SIM_API_KEY=your_key_here
```

Then run migrations:

```bash
php artisan migrate
```

The sync will run automatically at 04:00. To do an initial backfill for a specific month:

```bash
php artisan statsim:sync 2026 4
```

Ensure the Laravel scheduler cron is registered on the server:

```
* * * * * cd /path/to/project && php artisan schedule:run >> /dev/null 2>&1
```