### PR TITLE
Fix roster syncing for non-rostered staff members

### DIFF
--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -28,6 +28,11 @@ class Staff extends Model
     public static function fromFacilityInfoDTO(\App\DTOs\VatusaFacilityInfoDTO $infoDTO)
     {
         foreach ($infoDTO->roles as $role) {
+            // User does not exist in users table - gather from out of division
+            if (is_null(User::find($role['cid']))) {
+                User::createFromVatusa($role['cid']);
+            }
+
             switch($role['role']) {
                 case 'ATM':
                     static::create([

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\DTOs\VatusaRosterUser;
 use App\Enums\ControllerRating;
+use Http;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -194,5 +195,14 @@ class User extends Authenticatable
         return $this->belongsToMany(Event::class, 'event_positions')
                     ->withPivot('requested_position', 'start', 'end', 'note', 'position_status')
                     ->withTimestamps();
+    }
+
+    public static function createFromVatusa(int $id) {
+        $userData = Http::get(config('app.vatusa_api_url') . '/v2/user/' . $id, [
+            'apikey' => config('app.vatusa_api_key')
+        ])->throw()->json()['data'] ?? throw new \Exception('Failed to fetch user data for CID ' . $id);
+
+        $vatusaUser = new VatusaRosterUser($userData);
+        self::updateFromVatusa($vatusaUser);
     }
 }

--- a/tests/Feature/RosterSyncTest.php
+++ b/tests/Feature/RosterSyncTest.php
@@ -47,6 +47,6 @@ test('given a vatusa user, when converted to a database user, then a database us
 });
 
 test('given the roster sync function exists, when the roster sync function is executed, then it executes without errors', function() {
-    SyncRoster::dispatch();
-
+    $syncJob = new SyncRoster();
+    $syncJob->handle();
 });


### PR DESCRIPTION
Fixes an issue where non-rostered staff members (me... sorry) would cause a foreign key violation upon roster sync in a fresh database.

We are not seeing this in production since I already exist in the staging user database. This would have caused a failure in production however.