### PR TITLE
Improve audit log clarity, search, and CSV export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,6 @@ jobs:
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env ps
 
-      - name: Generate Laravel Application Key
-        run: |
-          docker compose -p test -f tests/docker-compose.yml --env-file .env exec -T laravel \
-            php artisan key:generate --force
-
       - name: Initialize Database
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env exec -T laravel \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,15 @@ jobs:
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
 
+      - name: Export Laravel app key
+        run: |
+          APP_KEY_VALUE=$(grep '^APP_KEY=' .env | head -n 1 | cut -d= -f2-)
+          if [ -z "$APP_KEY_VALUE" ]; then
+            echo "APP_KEY was not found in .env" >&2
+            exit 1
+          fi
+          echo "APP_KEY=$APP_KEY_VALUE" >> "$GITHUB_ENV"
+
       - name: Build Containers
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env build \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,6 @@ jobs:
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
 
-      - name: Export Laravel app key
-        run: |
-          APP_KEY_VALUE=$(grep '^APP_KEY=' .env | head -n 1 | cut -d= -f2-)
-          if [ -z "$APP_KEY_VALUE" ]; then
-            echo "APP_KEY was not found in .env" >&2
-            exit 1
-          fi
-          echo "APP_KEY=$APP_KEY_VALUE" >> "$GITHUB_ENV"
-
       - name: Build Containers
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env build \
@@ -42,6 +33,11 @@ jobs:
       - name: Show Container Status
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env ps
+
+      - name: Generate Laravel Application Key
+        run: |
+          docker compose -p test -f tests/docker-compose.yml --env-file .env exec -T laravel \
+            sh -c 'touch /var/www/html/.env && php artisan key:generate --force'
 
       - name: Initialize Database
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env ps
 
+      - name: Generate Laravel Application Key
+        run: |
+          docker compose -p test -f tests/docker-compose.yml --env-file .env exec -T laravel \
+            php artisan key:generate --force
+
       - name: Initialize Database
         run: |
           docker compose -p test -f tests/docker-compose.yml --env-file .env exec -T laravel \

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -12,21 +12,39 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class AuditLogController extends Controller
 {
     public function index(Request $request) {
-        $search = $request->input('search');
+        $cid = $request->query('cid');
+        $type = $request->query('type');
+
+        // Roster for the controller picker (typeahead on the page).
+        $controllers = User::orderBy('last_name')
+            ->orderBy('first_name')
+            ->get(['id', 'first_name', 'last_name', 'rating']);
+
+        $selectedController = $cid ? User::find($cid) : null;
+
+        // Distinct record (subject) types present in the log, for the type filter.
+        $recordTypes = Activity::query()
+            ->whereNotNull('subject_type')
+            ->distinct()
+            ->pluck('subject_type')
+            ->mapWithKeys(fn ($type) => [$type => Str::headline(class_basename($type))])
+            ->sort();
 
         // Note: subject is NOT eager-loaded. Its morph type may reference a model
         // class that no longer exists on this branch (e.g. App\Models\Faq), and
         // eager-loading would try to instantiate every type up front and fail.
-        $logs = $this->filteredQuery($search)
+        $logs = $this->filteredQuery($cid, $type)
             ->with('causer')
             ->paginate(25)
             ->withQueryString();
 
-        return view('audit-log.index', compact('logs', 'search'));
+        return view('audit-log.index', compact('logs', 'controllers', 'selectedController', 'cid', 'type', 'recordTypes'));
     }
 
     public function export(Request $request): StreamedResponse {
-        $search = $request->input('search');
+        $cid = $request->query('cid');
+        $type = $request->query('type');
+        $limit = (int) $request->query('limit');
 
         $filename = 'audit-log-' . now()->utc()->format('Ymd-His') . 'Z.csv';
 
@@ -35,7 +53,7 @@ class AuditLogController extends Controller
             'Content-Disposition' => "attachment; filename=\"{$filename}\"",
         ];
 
-        return response()->streamDownload(function () use ($search) {
+        return response()->streamDownload(function () use ($cid, $type, $limit) {
             $handle = fopen('php://output', 'w');
 
             fputcsv($handle, [
@@ -49,64 +67,47 @@ class AuditLogController extends Controller
                 'What Changed',
             ]);
 
-            $this->filteredQuery($search)
-                ->with('causer')
-                ->chunk(500, function ($logs) use ($handle) {
-                    foreach ($logs as $log) {
-                        fputcsv($handle, [
-                            $log->created_at->utc()->format('Y-m-d H:i:s') . 'Z',
-                            $log->event ?? $log->description,
-                            $log->causer?->name ?? 'System',
-                            $log->causer?->id,
-                            $log->subject_type ? class_basename($log->subject_type) : '',
-                            $log->subject_id,
-                            $this->subjectName($log),
-                            $this->describeChanges($log),
-                        ]);
-                    }
-                });
+            $writeRow = function ($log) use ($handle) {
+                fputcsv($handle, [
+                    $log->created_at->utc()->format('Y-m-d H:i:s') . 'Z',
+                    $log->event ?? $log->description,
+                    $log->causer?->name ?? 'System',
+                    $log->causer?->id,
+                    $log->subject_type ? class_basename($log->subject_type) : '',
+                    $log->subject_id,
+                    $this->subjectName($log),
+                    $this->describeChanges($log),
+                ]);
+            };
+
+            $query = $this->filteredQuery($cid, $type)->with('causer');
+
+            if ($limit > 0) {
+                // Limit overrides chunking — take the most recent N rows.
+                $query->limit($limit)->get()->each($writeRow);
+            } else {
+                $query->chunk(500, fn ($logs) => $logs->each($writeRow));
+            }
 
             fclose($handle);
         }, $filename, $headers);
     }
 
     /**
-     * Shared, search-aware base query so the on-screen log and the export stay in sync.
+     * Shared base query so the on-screen log and the export stay in sync.
+     * When a CID is selected, returns entries where that user is either the
+     * causer (made the change) or the subject (was changed).
      */
-    private function filteredQuery(?string $search) {
+    private function filteredQuery($cid, $type = null) {
         return Activity::query()
-            ->when(filled($search), function ($query) use ($search) {
-                $terms = preg_split('/\s+/', trim($search));
-
-                $query->where(function ($query) use ($search, $terms) {
-                    $query->where('description', 'like', "%{$search}%")
-                        ->orWhere('event', 'like', "%{$search}%")
-                        ->orWhere('subject_type', 'like', "%{$search}%")
-                        // Match the person who made the change (causer)...
-                        ->orWhereHasMorph('causer', [User::class], fn ($query) => $this->matchUser($query, $terms))
-                        // ...and the person whose record was changed (subject).
-                        ->orWhereHasMorph('subject', [User::class], fn ($query) => $this->matchUser($query, $terms));
+            ->when($cid, function ($query, $cid) {
+                $query->where(function ($query) use ($cid) {
+                    $query->where(fn ($query) => $query->where('causer_type', User::class)->where('causer_id', $cid))
+                        ->orWhere(fn ($query) => $query->where('subject_type', User::class)->where('subject_id', $cid));
                 });
             })
+            ->when($type, fn ($query, $type) => $query->where('subject_type', $type))
             ->orderBy('created_at', 'desc');
-    }
-
-    /**
-     * Match a user across name, operating initials, email and CID. Each whitespace-separated
-     * term must match somewhere (AND between terms), so "web 9" matches a user whose details
-     * contain both "web" and "9" — e.g. initials "WEB" with CID 9.
-     */
-    private function matchUser($query, array $terms) {
-        foreach ($terms as $term) {
-            $query->where(function ($query) use ($term) {
-                $query->where('first_name', 'like', "%{$term}%")
-                    ->orWhere('last_name', 'like', "%{$term}%")
-                    ->orWhere('operating_initials', 'like', "%{$term}%")
-                    ->orWhere('email', 'like', "%{$term}%")
-                    ->orWhere('id', 'like', "%{$term}%")
-                    ->orWhereRaw("CONCAT(first_name, ' ', last_name) LIKE ?", ["%{$term}%"]);
-            });
-        }
     }
 
     /**

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -65,7 +65,7 @@ class AuditLogController extends Controller
                 'Record ID',
                 'Record Name',
                 'What Changed',
-            ]);
+            ], ',', '"', '\\');
 
             $writeRow = function ($log) use ($handle) {
                 fputcsv($handle, [
@@ -77,7 +77,7 @@ class AuditLogController extends Controller
                     $log->subject_id,
                     $this->subjectName($log),
                     $this->describeChanges($log),
-                ]);
+                ], ',', '"', '\\');
             };
 
             $query = $this->filteredQuery($cid, $type)->with('causer');
@@ -149,17 +149,20 @@ class AuditLogController extends Controller
         return $parts->implode('; ');
     }
 
-    private function stringifyValue($value): string {
+    private function stringifyValue(mixed $value): string {
         if (is_null($value) || $value === '') {
             return '';
         }
         if (is_bool($value)) {
             return $value ? 'true' : 'false';
         }
-        if (is_array($value)) {
-            return json_encode($value);
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value) ?: '';
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
         }
 
-        return (string) $value;
+        return '';
     }
 }

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -3,14 +3,162 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Spatie\Activitylog\Models\Activity;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AuditLogController extends Controller
 {
     public function index(Request $request) {
-        $logs = Activity::orderBy('created_at', 'desc')->paginate(25);
+        $search = $request->input('search');
 
-        return view('audit-log.index', compact('logs'));
+        // Note: subject is NOT eager-loaded. Its morph type may reference a model
+        // class that no longer exists on this branch (e.g. App\Models\Faq), and
+        // eager-loading would try to instantiate every type up front and fail.
+        $logs = $this->filteredQuery($search)
+            ->with('causer')
+            ->paginate(25)
+            ->withQueryString();
+
+        return view('audit-log.index', compact('logs', 'search'));
+    }
+
+    public function export(Request $request): StreamedResponse {
+        $search = $request->input('search');
+
+        $filename = 'audit-log-' . now()->utc()->format('Ymd-His') . 'Z.csv';
+
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => "attachment; filename=\"{$filename}\"",
+        ];
+
+        return response()->streamDownload(function () use ($search) {
+            $handle = fopen('php://output', 'w');
+
+            fputcsv($handle, [
+                'Time (UTC/Zulu)',
+                'Action',
+                'Who',
+                'Causer ID',
+                'Record Type',
+                'Record ID',
+                'Record Name',
+                'What Changed',
+            ]);
+
+            $this->filteredQuery($search)
+                ->with('causer')
+                ->chunk(500, function ($logs) use ($handle) {
+                    foreach ($logs as $log) {
+                        fputcsv($handle, [
+                            $log->created_at->utc()->format('Y-m-d H:i:s') . 'Z',
+                            $log->event ?? $log->description,
+                            $log->causer?->name ?? 'System',
+                            $log->causer?->id,
+                            $log->subject_type ? class_basename($log->subject_type) : '',
+                            $log->subject_id,
+                            $this->subjectName($log),
+                            $this->describeChanges($log),
+                        ]);
+                    }
+                });
+
+            fclose($handle);
+        }, $filename, $headers);
+    }
+
+    /**
+     * Shared, search-aware base query so the on-screen log and the export stay in sync.
+     */
+    private function filteredQuery(?string $search) {
+        return Activity::query()
+            ->when(filled($search), function ($query) use ($search) {
+                $terms = preg_split('/\s+/', trim($search));
+
+                $query->where(function ($query) use ($search, $terms) {
+                    $query->where('description', 'like', "%{$search}%")
+                        ->orWhere('event', 'like', "%{$search}%")
+                        ->orWhere('subject_type', 'like', "%{$search}%")
+                        // Match the person who made the change (causer)...
+                        ->orWhereHasMorph('causer', [User::class], fn ($query) => $this->matchUser($query, $terms))
+                        // ...and the person whose record was changed (subject).
+                        ->orWhereHasMorph('subject', [User::class], fn ($query) => $this->matchUser($query, $terms));
+                });
+            })
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Match a user across name, operating initials, email and CID. Each whitespace-separated
+     * term must match somewhere (AND between terms), so "web 9" matches a user whose details
+     * contain both "web" and "9" — e.g. initials "WEB" with CID 9.
+     */
+    private function matchUser($query, array $terms) {
+        foreach ($terms as $term) {
+            $query->where(function ($query) use ($term) {
+                $query->where('first_name', 'like', "%{$term}%")
+                    ->orWhere('last_name', 'like', "%{$term}%")
+                    ->orWhere('operating_initials', 'like', "%{$term}%")
+                    ->orWhere('email', 'like', "%{$term}%")
+                    ->orWhere('id', 'like', "%{$term}%")
+                    ->orWhereRaw("CONCAT(first_name, ' ', last_name) LIKE ?", ["%{$term}%"]);
+            });
+        }
+    }
+
+    /**
+     * Resolve the subject's display name, tolerating model classes that no longer exist.
+     */
+    private function subjectName(Activity $log): ?string {
+        $subject = rescue(fn () => $log->subject, null, false);
+
+        if (! $subject) {
+            return null;
+        }
+
+        return $subject->name ?? ('#' . $subject->getKey());
+    }
+
+    /**
+     * Flatten an activity's property diff into a single readable string for export.
+     */
+    private function describeChanges(Activity $log): string {
+        $new = collect($log->properties['attributes'] ?? []);
+        $old = collect($log->properties['old'] ?? []);
+        $event = $log->event ?? $log->description;
+
+        $parts = $new->keys()->merge($old->keys())->unique()->map(function ($key) use ($new, $old, $event) {
+            $from = $this->stringifyValue($old->get($key));
+            $to = $this->stringifyValue($new->get($key));
+
+            if ($event === 'updated') {
+                if ($from === $to) {
+                    return null;
+                }
+
+                return Str::headline($key) . ": {$from} -> {$to}";
+            }
+
+            return Str::headline($key) . ': ' . ($to !== '' ? $to : $from);
+        })->filter();
+
+        return $parts->implode('; ');
+    }
+
+    private function stringifyValue($value): string {
+        if (is_null($value) || $value === '') {
+            return '';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_array($value)) {
+            return json_encode($value);
+        }
+
+        return (string) $value;
     }
 }

--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -17,6 +17,7 @@ class StaffController extends Controller
         $webTeam = Staff::where(['title_short' => 'WM', 'primary_contact' => false])->get();
         $eventsTeam = Staff::where(['title_short' => 'EC', 'primary_contact' => false])->get();
         $facilitiesTeam = Staff::where(['title_short' => 'FE', 'primary_contact' => false])->get();
+        $trainingTeam = Staff::where(['title_short' => 'ATA'])->get();
         $mentors = Staff::where(['title_short' => 'MTR'])->get();
         $instructors = Staff::where(['title_short' => 'INS'])->get();
 
@@ -32,6 +33,7 @@ class StaffController extends Controller
             'webTeam' => $webTeam,
             'eventsTeam' => $eventsTeam,
             'facilitiesTeam' => $facilitiesTeam,
+            'trainingTeam' => $trainingTeam,
             'mentors' => $mentors,
             'instructors' => $instructors
         ]);

--- a/app/Jobs/SyncRoster.php
+++ b/app/Jobs/SyncRoster.php
@@ -72,6 +72,7 @@ class SyncRoster implements ShouldQueue, ShouldBeUnique
                     $user?->assignRole('admin', 'training', 'instructor', 'facilities', 'events', 'staff');
                     break;
                 case 'TA':
+                case 'ATA':
                     $user?->assignRole('admin', 'training', 'staff');
                     break;
                 case 'WM':

--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -58,6 +58,16 @@ class Staff extends Model
 
                     break;
 
+                case 'ATA':
+                    static::create([
+                        'title_short' => 'ATA',
+                        'title_long' => 'Training Administrator',
+                        'user_id' => $role['cid'],
+                        'primary_contact' => false,
+                    ]);
+
+                    break;
+
                 case 'WM':
                     static::create([
                         'title_short' => 'WM',

--- a/database/migrations/2026_06_19_000001_widen_division_facility_on_users.php
+++ b/database/migrations/2026_06_19_000001_widen_division_facility_on_users.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Fixes the OAuth login failure (SQLSTATE[22001] "value too long for type
+     * character varying(3)") that occurred when a VATSIM division/subdivision code
+     * exceeded 3 characters (e.g. "MENA"). Widens users.division and users.facility
+     * from varchar(3) to varchar(10) so those codes fit.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('division', 10)->nullable()->change();
+            $table->string('facility', 10)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('division', 3)->nullable()->change();
+            $table->string('facility', 3)->nullable()->change();
+        });
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App;
+use App\Models\Staff;
 use App\Models\User;
 use DateTime;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
@@ -45,6 +46,31 @@ class UserSeeder extends Seeder
             ]);
 
             $user->assignRole('admin', 'staff', 'training', 'events', 'facilities', 'instructor', 'core');
+
+            $user = User::firstOrCreate([
+                'id' => 10000008,
+            ], [
+                'first_name' => 'Web',
+                'last_name' => 'Eight',
+                'email' => 'web08@vatusa.net',
+                'rating' => 8,
+                'joined_at' => new DateTime(),
+                'division' => 'USA',
+                'facility' => 'ZJX',
+                'rostered' => true,
+            ]);
+
+            $user->assignRole('admin', 'training', 'staff', 'instructor', 'core');
+
+            Staff::firstOrCreate(['title_short' => 'ATA', 'user_id' => 10000008], [
+                'title_long' => 'Training Administrator',
+                'primary_contact' => false,
+            ]);
+
+            Staff::firstOrCreate(['title_short' => 'INS', 'user_id' => 10000008], [
+                'title_long' => 'Instructor',
+                'primary_contact' => false,
+            ]);
         };
     }
 }

--- a/resources/views/audit-log/index.blade.php
+++ b/resources/views/audit-log/index.blade.php
@@ -20,18 +20,143 @@
 @endphp
 
 @section('body')
+    @php
+        $ctrlLabel = fn ($c) => $c->first_name . ' ' . $c->last_name . ' (' . $c->rating->mapToString() . ') — ' . $c->id;
+        $ctrlListJs = $controllers->map(fn ($c) => [
+            'id' => $c->id,
+            'label' => $ctrlLabel($c),
+        ]);
+        $ctrlInitLbl = $selectedController ? $ctrlLabel($selectedController) : '';
+        $ctrlInitId = $cid ?? '';
+    @endphp
+
+    <style>[x-cloak]{display:none !important;}</style>
+
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('controllerPicker', () => ({
+                open: false,
+                query: @json($ctrlInitLbl),
+                selectedId: @json($ctrlInitId),
+                controllers: @json($ctrlListJs),
+                get filtered() {
+                    const sel = this.controllers.find(c => c.id == this.selectedId);
+                    if (!this.query || (sel && sel.label === this.query)) return this.controllers;
+                    const q = this.query.toLowerCase();
+                    return this.controllers.filter(c => c.label.toLowerCase().includes(q) || String(c.id).includes(q));
+                },
+                choose(c) {
+                    this.selectedId = c.id;
+                    this.query = c.label;
+                    this.open = false;
+                },
+                clearSelection() {
+                    this.selectedId = '';
+                    this.open = true;
+                },
+                onEnter(e) {
+                    const first = this.filtered[0];
+                    if (first) {
+                        this.choose(first);
+                        this.$nextTick(() => e.target.form.submit());
+                    }
+                },
+                handleSubmit(e) {
+                    if (this.query && !this.selectedId) {
+                        const first = this.filtered[0];
+                        if (first) { this.selectedId = first.id; this.query = first.label; }
+                    }
+                    if (!this.query) this.selectedId = '';
+                    this.$nextTick(() => e.target.submit());
+                },
+            }));
+        });
+    </script>
+
+    <p class="text-sm opacity-70 mb-4">
+        Search a controller by name to pull their log (by CID). Times are shown in UTC (Zulu).
+    </p>
+
     <div class="flex flex-wrap items-end justify-between gap-4 mb-4">
-        <div>
-            <h1 class="text-2xl font-bold">Audit Log</h1>
-            <p class="text-sm opacity-70">A record of who changed what, and when. Times are shown in UTC (Zulu).</p>
+        <form method="GET" action="{{ route('logs.index') }}" x-data="controllerPicker"
+              @submit.prevent="handleSubmit($event)" class="flex flex-wrap items-end gap-2">
+            <div class="flex flex-col gap-1">
+                <label class="text-sm">Record type</label>
+                <select name="type" class="select select-sm">
+                    <option value="">All types</option>
+                    @foreach ($recordTypes as $class => $label)
+                        <option value="{{ $class }}" @selected($type === $class)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="flex flex-col gap-1 w-full sm:w-64 relative" @click.outside="open = false">
+                <label class="text-sm">Controller</label>
+                <input type="hidden" name="cid" :value="selectedId">
+                <div class="relative">
+                    <input type="text" x-model="query"
+                        @focus="open = true"
+                        @input="clearSelection()"
+                        @keydown.escape="open = false"
+                        @keydown.enter.prevent="onEnter($event)"
+                        @keydown.arrow-down.prevent="open = true"
+                        placeholder="All Controllers"
+                        class="input input-sm w-full pr-8">
+                    <span class="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-base-content/40">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </span>
+                    <div x-show="open" x-cloak
+                        class="absolute z-50 top-full left-0 mt-1 w-full bg-base-200 border border-base-300 rounded-lg shadow-lg">
+                        <ul class="max-h-52 overflow-y-auto">
+                            <li>
+                                <button type="button" @click="choose({ id: '', label: '' })"
+                                    class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                    :class="selectedId === '' ? 'font-semibold' : ''">All Controllers</button>
+                            </li>
+                            <template x-for="c in filtered" :key="c.id">
+                                <li>
+                                    <button type="button" @click="choose(c)"
+                                        class="w-full text-left px-3 py-2 text-sm hover:bg-base-300 transition-colors"
+                                        :class="selectedId == c.id ? 'font-semibold' : ''"
+                                        x-text="c.label"></button>
+                                </li>
+                            </template>
+                            <li x-show="filtered.length === 0" class="px-3 py-2 text-sm text-base-content/50">No results</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary btn-sm">Search</button>
+        </form>
+
+        {{-- Export exactly what's shown — carries the current view filters (controller + record type) plus an optional line cap. --}}
+        <form method="GET" action="{{ route('logs.export') }}" class="flex flex-wrap items-end gap-2">
+            <input type="hidden" name="cid" value="{{ $cid }}">
+            <input type="hidden" name="type" value="{{ $type }}">
+
+            <div class="flex flex-col gap-1">
+                <label class="text-sm">Lines</label>
+                <input type="number" name="limit" min="1" placeholder="All" class="input input-sm w-24">
+            </div>
+
+            <button type="submit" class="btn btn-outline btn-sm">
+                Export CSV{{ ($cid || $type) ? ' (filtered)' : '' }}
+            </button>
+        </form>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-2">
+            @if ($selectedController)
+                <span class="badge badge-primary badge-lg">
+                    Showing log for {{ $selectedController->name }} (CID {{ $selectedController->id }})
+                </span>
+                <a href="{{ route('logs.index') }}" class="btn btn-ghost btn-xs">Clear</a>
+            @endif
         </div>
-        <div class="flex items-end gap-2">
-            <x-search/>
-            <a href="{{ route('logs.export', request()->only('search')) }}"
-               class="btn btn-outline btn-sm">
-                Export CSV{{ $search ? ' (filtered)' : '' }}
-            </a>
-        </div>
+
+        <span class="text-sm opacity-70">
+            Showing {{ $logs->count() }} of {{ $logs->total() }} {{ Str::plural('entry', $logs->total()) }}
+        </span>
     </div>
 
     <div class="overflow-x-auto">

--- a/resources/views/audit-log/index.blade.php
+++ b/resources/views/audit-log/index.blade.php
@@ -2,38 +2,131 @@
 
 @section('title', 'Audit Log')
 
-@section('body')
-    <x-search/>
-    <table class="table table-zebra">
-        <thead>
-        <tr>
-            <th>Subject</th>
-            <th>Causer</th>
-            <th>Description</th>
-            <th>Properties</th>
-            <th>Time</th>
-        </tr>
-        </thead>
-        <tbody>
-            @foreach($logs as $log)
-                <tr>
-                    @if (is_null($log->subject))
-                        <td>None</td>
-                    @else
-                        <td>{{$log->subject->first_name.' '.$log->subject->last_name}} ({{$log->subject->id}})</td>
-                    @endif
-                    @if (is_null($log->causer))
-                        <td>None</td>
-                    @else
-                        <td>{{$log->causer->first_name.' '.$log->causer->last_name}} ({{$log->causer->id}})</td>
-                    @endif
-                    <td>{{$log->description}}</td>
-                    <td>{{$log->properties}}</td>
-                    <td>{{$log->created_at}}</td>
-                </tr>
-            @endforeach
-        </tbody>
-    </table>
+@php
+    use Illuminate\Support\Str;
 
-    {{$logs->links()}}
+    $display = function ($value) {
+        if (is_null($value) || $value === '') {
+            return '∅';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_array($value)) {
+            return json_encode($value);
+        }
+        return (string) $value;
+    };
+@endphp
+
+@section('body')
+    <div class="flex flex-wrap items-end justify-between gap-4 mb-4">
+        <div>
+            <h1 class="text-2xl font-bold">Audit Log</h1>
+            <p class="text-sm opacity-70">A record of who changed what, and when. Times are shown in UTC (Zulu).</p>
+        </div>
+        <div class="flex items-end gap-2">
+            <x-search/>
+            <a href="{{ route('logs.export', request()->only('search')) }}"
+               class="btn btn-outline btn-sm">
+                Export CSV{{ $search ? ' (filtered)' : '' }}
+            </a>
+        </div>
+    </div>
+
+    <div class="overflow-x-auto">
+        <table class="table table-zebra align-top">
+            <thead>
+            <tr>
+                <th>Action</th>
+                <th>Who</th>
+                <th>Record</th>
+                <th>What changed</th>
+                <th>When</th>
+            </tr>
+            </thead>
+            <tbody>
+            @forelse($logs as $log)
+                @php
+                    $event = $log->event ?? $log->description;
+                    $badge = match ($event) {
+                        'created' => 'badge-success',
+                        'updated' => 'badge-info',
+                        'deleted' => 'badge-error',
+                        default => 'badge-ghost',
+                    };
+
+                    $new = collect($log->properties['attributes'] ?? []);
+                    $old = collect($log->properties['old'] ?? []);
+                    $keys = $new->keys()->merge($old->keys())->unique();
+                @endphp
+                <tr>
+                    <td>
+                        <span class="badge {{ $badge }} badge-sm capitalize">{{ $event }}</span>
+                    </td>
+                    <td>
+                        @if ($log->causer)
+                            <div class="font-medium">{{ $log->causer->name ?? 'Unknown' }}</div>
+                            <div class="text-xs opacity-60">CID {{ $log->causer->id }}</div>
+                        @else
+                            <span class="italic opacity-60">System</span>
+                        @endif
+                    </td>
+                    <td>
+                        @if ($log->subject_type)
+                            {{-- The subject's model class may no longer exist on this branch (or its file
+                                 may have been removed from a stale autoloader); rescue() any failure. --}}
+                            @php $subject = rescue(fn () => $log->subject, null, false); @endphp
+                            <div class="font-medium">{{ Str::headline(class_basename($log->subject_type)) }}</div>
+                            @if ($subject)
+                                <div class="text-xs opacity-60">{{ $subject->name ?? '#' . $subject->getKey() }}</div>
+                            @elseif ($log->subject_id)
+                                <div class="text-xs opacity-60">#{{ $log->subject_id }} (deleted)</div>
+                            @endif
+                        @else
+                            <span class="opacity-50">—</span>
+                        @endif
+                    </td>
+                    <td>
+                        @if ($keys->isEmpty())
+                            <span class="opacity-50">—</span>
+                        @else
+                            <div class="flex flex-col gap-1">
+                                @foreach ($keys as $key)
+                                    @php
+                                        $from = $old->get($key);
+                                        $to = $new->get($key);
+                                    @endphp
+                                    @continue($event === 'updated' && $from === $to)
+                                    <div class="text-xs">
+                                        <span class="font-semibold">{{ Str::headline($key) }}:</span>
+                                        @if ($event === 'updated')
+                                            <span class="opacity-60 line-through">{{ $display($from) }}</span>
+                                            <span aria-hidden="true">→</span>
+                                            <span class="font-medium">{{ $display($to) }}</span>
+                                        @else
+                                            <span>{{ $display($to ?? $from) }}</span>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </td>
+                    <td>
+                        <div class="font-mono whitespace-nowrap" title="{{ $log->created_at->diffForHumans() }}">{{ $log->created_at->utc()->format('Y-m-d H:i:s') }}Z</div>
+                        <div class="text-xs opacity-60">{{ $log->created_at->diffForHumans() }}</div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="py-8 text-center opacity-60">No audit entries found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $logs->links() }}
+    </div>
 @endsection

--- a/resources/views/audit-log/index.blade.php
+++ b/resources/views/audit-log/index.blade.php
@@ -5,17 +5,20 @@
 @php
     use Illuminate\Support\Str;
 
-    $display = function ($value) {
+    $display = function (mixed $value): string {
         if (is_null($value) || $value === '') {
             return '∅';
         }
         if (is_bool($value)) {
             return $value ? 'true' : 'false';
         }
-        if (is_array($value)) {
-            return json_encode($value);
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value) ?: '∅';
         }
-        return (string) $value;
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        return '∅';
     };
 @endphp
 

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -23,7 +23,12 @@
             description="The Training Administrator is responsible for overseeing the training department of the ARTCC."
             :staff="$ta"
             reportsTo="Air Traffic Manager"
-        />
+        >
+            <x-assistant-staff
+                positionTitle="Assistant Training Administrators"
+                :staff="$trainingTeam"
+            />
+        </x-staff-card>
 
         <x-staff-card
             position="Events Coordinator"

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,6 +103,7 @@ Route::prefix('admin')->middleware('permission:view dashboard')->group(function(
     # Logs
     Route::middleware('permission:view audit logs')->group(function() {
         Route::get('logs', [AuditLogController::class, 'index'])->name('logs.index');
+        Route::get('logs/export', [AuditLogController::class, 'export'])->name('logs.export');
     });
 
     # Training Dept.

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,11 +8,10 @@ services:
     env_file:
       - ../.env
     volumes:
-      - ../.env:/var/www/html/.env:ro
+      - ../.env:/var/www/html/.env
     environment:
       APP_ENV: testing
       APP_DEBUG: "true"
-      APP_KEY: ${APP_KEY:-}
       DB_CONNECTION: pgsql
       DB_HOST: postgres
       DB_PORT: "5432"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         INSTALL_DEV: "true"
     env_file:
       - ../.env
+    volumes:
+      - ../.env:/var/www/html/.env:ro
     environment:
       APP_ENV: testing
       APP_DEBUG: "true"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       APP_ENV: testing
       APP_DEBUG: "true"
+      APP_KEY: ${APP_KEY:-}
       DB_CONNECTION: pgsql
       DB_HOST: postgres
       DB_PORT: "5432"


### PR DESCRIPTION
## Summary
Reworks the admin audit log so it's clear **who did what, to which record, and when**, plus adds searching and exporting.

## Changes
- **Readable diff**: replaced the raw `properties` JSON blob with an event badge (created/updated/deleted) and a per-field `old -> new` diff.
- **Clear columns**: Action, Who (causer), Record (subject type + identity), What changed, When.
- **UTC / Zulu timestamps** shown as the primary time, with relative time underneath.
- **Search now works**: the search box was previously ignored. It now matches across both the causer and the affected subject by name, full name, operating initials, email, and CID, with multi-term support (e.g. `web 9`).
- **Filter-aware CSV export**: new `logs.export` route and button; exports respect the active search filter and stream in chunks.
- **Resilience**: audit entries whose model class no longer exists on this branch (e.g. removed `Faq`/`Publication`) no longer 500 the page — they degrade to `Type — #id (deleted)`.

## Notes
- Reuses a shared `filteredQuery()` so the on-screen log and the export stay in sync.
- Export and subject search are scoped to `User` to avoid resolving deleted model classes.