### PR TITLE
Update lint.yml to remove develop branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,8 @@ name: linter
 on:
   push:
     branches:
-      - develop
       - main
   pull_request:
-    branches:
-      - develop
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Removed 'develop' branch from push and pull request triggers.