### PR TITLE
Fix training ticket score not restoring after a validation error

### DIFF
--- a/resources/views/training-tickets/create.blade.php
+++ b/resources/views/training-tickets/create.blade.php
@@ -96,11 +96,11 @@
 
             <label for="score" class="label">Score</label>
             <div class="rating">
-                <input type="radio" name="score" value="1" class="mask mask-star" aria-label="1 star" @selected(old('score') == 1)>
-                <input type="radio" name="score" value="2" class="mask mask-star" aria-label="2 star" @selected(old('score') == 2)>
-                <input type="radio" name="score" value="3" class="mask mask-star" aria-label="3 star" @selected(old('score') == 3)>
-                <input type="radio" name="score" value="4" class="mask mask-star" aria-label="4 star" @selected(old('score') == 4)>
-                <input type="radio" name="score" value="5" class="mask mask-star" aria-label="5 star" @selected(old('score') == 5)>
+                <input type="radio" name="score" value="1" class="mask mask-star" aria-label="1 star" @checked(old('score') == 1)>
+                <input type="radio" name="score" value="2" class="mask mask-star" aria-label="2 star" @checked(old('score') == 2)>
+                <input type="radio" name="score" value="3" class="mask mask-star" aria-label="3 star" @checked(old('score') == 3)>
+                <input type="radio" name="score" value="4" class="mask mask-star" aria-label="4 star" @checked(old('score') == 4)>
+                <input type="radio" name="score" value="5" class="mask mask-star" aria-label="5 star" @checked(old('score') == 5)>
             </div>
 
             <br>


### PR DESCRIPTION
## Summary
- Fixes #162 — training ticket score selection appeared to reset/not save whenever the create-ticket form redirected back with a validation error.
- Root cause: the score rating radios used `@selected()`, which is only meaningful on `<option>` elements. On `<input type="radio">` it's a silent no-op, so the flashed `old('score')` value never visually re-checked the star rating, even though the data itself was present.
- Swapped to `@checked()`, Blade's directive for exactly this case (checkboxes/radios). The `edit` form already did this correctly, which is why only `create` showed the bug.

## Test plan
- [x] On the Create Training Ticket form, select a score, submit with an invalid field (e.g. bad position format) to trigger a validation error, and confirm the previously selected score star rating is still shown checked after the redirect back.