### PR TITLE
Fix missing import causing statistics prefixes 500 error

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\PublicationsController;
 use App\Http\Controllers\RosterController;
 use App\Http\Controllers\StaffController;
 use App\Http\Controllers\StatisticsController;
+use App\Http\Controllers\StatisticsPrefixesController;
 use App\Http\Controllers\Training\SoloCertController;
 use App\Http\Controllers\Training\TrainingAssignmentController;
 use App\Http\Controllers\Training\TrainingTicketController;


### PR DESCRIPTION
## Summary
Adds the missing `use App\Http\Controllers\StatisticsPrefixesController;` import in routes/web.php. Without it, the class wasn't resolving, causing a 500 error.

Fixes #171