### PR TITLE
Add enhanced logging for reliability monitoring and staff actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,17 @@ BCRYPT_ROUNDS=12
 
 TRAINING_REQUEST_WEBHOOK_URL=something
 LOG_CHANNEL=stack
+# Comma-separated channels. Add "debug" to capture debug output in its own
+# rotating file (storage/logs/debug.log) without turning the main log down,
+# e.g. LOG_STACK=daily,debug. See docs/systems/logging.md.
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
+# Minimum level for the single/daily channels. Use "info" in production;
+# drop to "debug" to troubleshoot the roster or Statsim syncs.
 LOG_LEVEL=debug
+# Retention, in days, for the daily and debug channels.
+LOG_DAILY_DAYS=14
+LOG_DEBUG_DAYS=3
 
 DB_CONNECTION=pgsql
 DB_QUEUE_CONNECTION=pgsql

--- a/app/Http/Controllers/Admin/ManualContributorController.php
+++ b/app/Http/Controllers/Admin/ManualContributorController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\ManualContributor;
+use App\Support\PrivilegedAction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 
@@ -25,8 +26,10 @@ class ManualContributorController extends Controller
             'note' => 'nullable|string|max:100',
         ]);
 
-        ManualContributor::create($validated);
+        $contributor = ManualContributor::create($validated);
         Cache::forget('github_contributors');
+
+        PrivilegedAction::record(PrivilegedAction::CONTRIBUTOR_ADDED, $contributor, $validated);
 
         $label = $validated['github_username'] ? "@{$validated['github_username']}" : ($validated['display_name'] ?? 'Contributor');
 
@@ -35,8 +38,14 @@ class ManualContributorController extends Controller
 
     public function destroy(ManualContributor $contributor)
     {
+        // Snapshot before the delete; afterwards the row is gone and the audit
+        // entry would have nothing to describe but an ID.
+        $snapshot = $contributor->only(['github_username', 'display_name', 'section', 'note']);
+
         $contributor->delete();
         Cache::forget('github_contributors');
+
+        PrivilegedAction::record(PrivilegedAction::CONTRIBUTOR_REMOVED, $contributor, $snapshot);
 
         $label = $contributor->github_username ? "@{$contributor->github_username}" : ($contributor->display_name ?? 'Contributor');
 

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -6,6 +6,7 @@ use App\Jobs\SyncStatsimSessions;
 use App\Models\ControllerMonthlyStat;
 use App\Models\ControllerSession;
 use App\Models\User;
+use App\Support\PrivilegedAction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 
@@ -34,6 +35,14 @@ class StatisticsController extends Controller
             $cursor->addMonthNoOverflow();
             $count++;
         }
+
+        // A manual backfill rewrites published controller hours, so record who
+        // asked for it and over what range.
+        PrivilegedAction::record(PrivilegedAction::STATISTICS_SYNC_QUEUED, null, [
+            'from' => $from->format('Y-m'),
+            'to' => $to->format('Y-m'),
+            'months_queued' => $count,
+        ]);
 
         return back()->with('success', "Queued sync for {$count} month(s): {$from->format('M Y')} – {$to->format('M Y')}.");
     }

--- a/app/Http/Controllers/Training/SoloCertController.php
+++ b/app/Http/Controllers/Training/SoloCertController.php
@@ -11,9 +11,9 @@ use App\Mail\SoloCertRevoked;
 use App\Models\SoloCert;
 use App\Models\TrainingAssignment;
 use App\Models\User;
+use App\Support\PrivilegedAction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class SoloCertController extends Controller
@@ -74,11 +74,12 @@ class SoloCertController extends Controller
         CreateVatusaSoloCert::dispatch($soloCert);
         Mail::to($soloCert->user)->bcc([$soloCert->issuedBy, config('app.vatusa_facility').'-ta@vatusa.net'])->queue(new SoloCertIssued($soloCert));
 
-        Log::info('Solo cert issued', [
+        PrivilegedAction::record(PrivilegedAction::SOLO_CERT_ISSUED, $soloCert, [
             'solo_cert_id' => $soloCert->id,
-            'issued_by' => Auth::user()->id,
-            'user_id' => $validated['userId'],
+            'cid' => $validated['userId'],
             'position' => $validated['position'],
+            'expires' => $soloCert->expires?->toDateString(),
+            'assignments_moved_to_solo' => $relaventAssignments->count(),
         ]);
 
         return redirect(route('solo-certs.index'))->with('success', 'Solo certification created successfully.');
@@ -108,6 +109,14 @@ class SoloCertController extends Controller
         $soloCert->save();
 
         Mail::to($soloCert->user)->bcc([$soloCert->issuedBy, config('app.vatusa_facility').'-ta@vatusa.net'])->queue(new SoloCertRevoked($soloCert));
+
+        PrivilegedAction::record(PrivilegedAction::SOLO_CERT_REVOKED, $soloCert, [
+            'solo_cert_id' => $soloCert->id,
+            'cid' => $soloCert->user_id,
+            'position' => $soloCert->position,
+            'originally_issued_by' => $soloCert->issued_by_id,
+            'assignments_returned_to_active' => $relaventAssignments->count(),
+        ]);
 
         return redirect(route('solo-certs.index'))->with('success', 'Solo certification revoked successfully.');
     }

--- a/app/Http/Controllers/Training/TrainingAssignmentController.php
+++ b/app/Http/Controllers/Training/TrainingAssignmentController.php
@@ -10,9 +10,9 @@ use App\Mail\TrainingAssignmentCreated;
 use App\Mail\TrainingAssignmentUpdated;
 use App\Models\Staff;
 use App\Models\TrainingAssignment;
+use App\Support\PrivilegedAction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class TrainingAssignmentController extends Controller
@@ -118,9 +118,13 @@ class TrainingAssignmentController extends Controller
             Mail::to($trainingAssignment->student->email)->bcc($trainingAssignment->instructor ?? null)->queue(new TrainingAssignmentUpdated($trainingAssignment));
         }
 
-        Log::info('Training assignment updated', [
+        PrivilegedAction::record(PrivilegedAction::TRAINING_ASSIGNMENT_UPDATED, $trainingAssignment, [
             'assignment_id' => $trainingAssignment->id,
-            'updated_by' => $user->id,
+            'student_cid' => $trainingAssignment->user_id,
+            'instructor_cid' => $trainingAssignment->instructor_id,
+            'status' => $trainingAssignment->status,
+            'active' => $trainingAssignment->active,
+            'student_notified' => (bool) ($validated['notifyUser'] ?? false),
         ]);
 
         return redirect()->back()->with('success', 'Training request updated successfully');
@@ -148,6 +152,11 @@ class TrainingAssignmentController extends Controller
 
         Mail::to($assignment->student->email)->bcc($assignment->instructor ?? null)->queue(new TrainingAssignmentUpdated($assignment));
 
+        PrivilegedAction::record(PrivilegedAction::TRAINING_ASSIGNMENT_CLAIMED, $assignment, [
+            'assignment_id' => $assignment->id,
+            'student_cid' => $assignment->user_id,
+        ]);
+
         return redirect()->back()->with('success', 'Training assignment claimed successfully');
     }
 
@@ -164,13 +173,26 @@ class TrainingAssignmentController extends Controller
             return redirect()->back()->with('error', 'Cannot update inactive training assignment.');
         }
 
+        $previousInstructorId = $assignment->instructor_id;
+        $dropped = false;
+
         if ($assignment->instructor_id == $user->id || $user->hasPermissionTo('manage students')) {
             $assignment->update([
                 'instructor_id' => null,
             ]);
+            $dropped = true;
         }
 
         Mail::to($assignment->student->email)->queue(new TrainingAssignmentUpdated($assignment));
+
+        PrivilegedAction::record(PrivilegedAction::TRAINING_ASSIGNMENT_DROPPED, $assignment, [
+            'assignment_id' => $assignment->id,
+            'student_cid' => $assignment->user_id,
+            'previous_instructor_cid' => $previousInstructorId,
+            // The route reports success either way; record whether the
+            // instructor was actually cleared so the trail is not misleading.
+            'instructor_cleared' => $dropped,
+        ]);
 
         return redirect()->back()->with('success', 'Training assignment dropped successfully');
     }
@@ -192,6 +214,13 @@ class TrainingAssignmentController extends Controller
             $assignment->active = false;
             $assignment->status = TrainingStatus::FORFEIT;
             $assignment->save();
+
+            PrivilegedAction::record(PrivilegedAction::TRAINING_ASSIGNMENT_FORFEITED, $assignment, [
+                'assignment_id' => $assignment->id,
+                'student_cid' => $assignment->user_id,
+                'instructor_cid' => $assignment->instructor_id,
+                'self_service' => $assignment->user_id == $user->id,
+            ]);
 
             return redirect()->back()->with('success', 'Training assignment deactivated successfully');
         } else {

--- a/app/Http/Controllers/VisitFacilityController.php
+++ b/app/Http/Controllers/VisitFacilityController.php
@@ -10,9 +10,9 @@ use App\Mail\VisitorRequestRejected;
 use App\Models\User;
 use App\Models\VisitorRequest;
 use App\Services\VisitingChecklistService;
+use App\Support\PrivilegedAction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class VisitFacilityController extends Controller
@@ -77,7 +77,11 @@ class VisitFacilityController extends Controller
         ]);
 
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestReceived($visitRequest));
-        Log::info('New visit request submitted for user '.$visitRequest->user_id.' by '.Auth::user()->id);
+
+        PrivilegedAction::record(PrivilegedAction::VISITOR_REQUEST_SUBMITTED, $visitRequest, [
+            'visit_request_id' => $visitRequest->id,
+            'cid' => $visitRequest->user_id,
+        ]);
 
         return redirect()->route('visit.index')->with('success', 'Visit request submitted successfully.');
     }
@@ -100,7 +104,13 @@ class VisitFacilityController extends Controller
         $visitRequest->status = VisitRequestStatus::DENIED;
         $visitRequest->save();
 
-        Log::info('Visit request for user '.$visitRequest->user_id.' denied. Reason: '.$validated['reason'].' Admin Notes: '.($validated['adminNotes'] ?? 'N/A').' by '.Auth::user()->id);
+        PrivilegedAction::record(PrivilegedAction::VISITOR_REQUEST_DENIED, $visitRequest, [
+            'visit_request_id' => $visitRequest->id,
+            'cid' => $visitRequest->user_id,
+            'reason' => $validated['reason'],
+            'admin_notes' => $validated['adminNotes'] ?? null,
+        ]);
+
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestRejected($visitRequest));
 
         return redirect()->back()->with('success', 'Visit request denied.');
@@ -135,7 +145,13 @@ class VisitFacilityController extends Controller
 
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestAccepted($visitRequest));
         AddUserToVisitingRoster::dispatch($visitRequest->user->id);
-        Log::info('Visit request for user '.$visitRequest->user_id.' approved. Operating Initials: '.$validated['operatingInitials'].' Admin Notes: '.($validated['adminNotes'] ?? 'N/A').' by '.Auth::user()->id);
+
+        PrivilegedAction::record(PrivilegedAction::VISITOR_REQUEST_APPROVED, $visitRequest, [
+            'visit_request_id' => $visitRequest->id,
+            'cid' => $visitRequest->user_id,
+            'operating_initials' => strtoupper($validated['operatingInitials']),
+            'admin_notes' => $validated['adminNotes'] ?? null,
+        ]);
 
         return redirect()->back()->with('success', 'Visit request approved.');
     }

--- a/app/Jobs/AddUserToVisitingRoster.php
+++ b/app/Jobs/AddUserToVisitingRoster.php
@@ -32,9 +32,16 @@ class AddUserToVisitingRoster implements ShouldQueue
         ]);
 
         if ($request->failed()) {
-            Log::error('Failed to add user '.$this->userId.' to visiting roster. Response: '.$request->body());
+            Log::error('Failed to add user to the VATUSA visiting roster', [
+                'user_id' => $this->userId,
+                'status' => $request->status(),
+                'body' => $request->body(),
+                'endpoint' => $URL,
+            ]);
         } else {
-            Log::info('Successfully added user '.$this->userId.' to visiting roster.');
+            Log::info('Added user to the VATUSA visiting roster', [
+                'user_id' => $this->userId,
+            ]);
         }
     }
 }

--- a/app/Jobs/Concerns/LogsJobRun.php
+++ b/app/Jobs/Concerns/LogsJobRun.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Gives a job a consistent, greppable run log: one debug line when it starts,
+ * one summary line with duration and counters when it finishes, and one error
+ * line if it blows up.
+ *
+ * Every line carries the same `run_id`, so a single run of a scheduled job can
+ * be pulled out of the log even when runs overlap:
+ *
+ *     grep '"run_id":"0193...' storage/logs/laravel.log
+ *
+ * Typical use:
+ *
+ *     $this->startRun(['month' => $this->month]);
+ *     ...
+ *     $this->countMetric('sessions_stored');
+ *     ...
+ *     $this->finishRun();
+ */
+trait LogsJobRun
+{
+    protected ?string $jobRunId = null;
+
+    protected ?float $jobRunStartedAt = null;
+
+    /** @var array<string, mixed> */
+    protected array $jobRunMetrics = [];
+
+    /**
+     * Level for the "completed" summary line. Jobs that run every minute should
+     * override this to `debug` so they do not drown the log.
+     */
+    protected function jobRunCompletionLevel(): string
+    {
+        return 'info';
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    protected function startRun(array $context = []): void
+    {
+        $this->jobRunId = (string) Str::uuid();
+        $this->jobRunStartedAt = microtime(true);
+        $this->jobRunMetrics = [];
+
+        Log::debug($this->jobRunName().' started', $this->jobRunContext($context));
+    }
+
+    /**
+     * Increment a counter reported in the completion summary.
+     */
+    protected function countMetric(string $key, int $by = 1): void
+    {
+        $this->jobRunMetrics[$key] = ($this->jobRunMetrics[$key] ?? 0) + $by;
+    }
+
+    /**
+     * Set (rather than increment) a value reported in the completion summary.
+     */
+    protected function setMetric(string $key, mixed $value): void
+    {
+        $this->jobRunMetrics[$key] = $value;
+    }
+
+    /**
+     * Per-phase detail, only emitted when the app is running at LOG_LEVEL=debug.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    protected function runDebug(string $message, array $context = []): void
+    {
+        Log::debug($this->jobRunName().': '.$message, $this->jobRunContext($context));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    protected function runWarning(string $message, array $context = []): void
+    {
+        Log::warning($this->jobRunName().': '.$message, $this->jobRunContext($context));
+    }
+
+    /**
+     * The summary line. This is the one that proves the job ran at all, so it
+     * is emitted on success even when nothing changed.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    protected function finishRun(array $context = []): void
+    {
+        Log::log(
+            $this->jobRunCompletionLevel(),
+            $this->jobRunName().' completed',
+            $this->jobRunContext($context)
+        );
+    }
+
+    /**
+     * The run stopped early for a known, non-exceptional reason — an upstream
+     * API returning an error, a malformed payload. Logged at error level like
+     * a failure, but without an exception trace that would say nothing useful.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    protected function abortRun(string $reason, array $context = []): void
+    {
+        Log::error($this->jobRunName().' aborted: '.$reason, $this->jobRunContext($context));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    protected function failRun(Throwable $e, array $context = []): void
+    {
+        Log::error($this->jobRunName().' failed: '.$e->getMessage(), $this->jobRunContext(array_merge($context, [
+            'exception' => get_class($e),
+            'origin' => $e->getFile().':'.$e->getLine(),
+            'trace' => $e->getTraceAsString(),
+        ])));
+    }
+
+    protected function jobRunName(): string
+    {
+        return class_basename(static::class);
+    }
+
+    /**
+     * Base context attached to every line of the run.
+     *
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function jobRunContext(array $extra = []): array
+    {
+        $context = [
+            'job' => static::class,
+            'run_id' => $this->jobRunId,
+        ];
+
+        if ($this->jobRunStartedAt !== null) {
+            $context['duration_ms'] = round((microtime(true) - $this->jobRunStartedAt) * 1000, 1);
+        }
+
+        return array_merge($context, $this->jobRunMetrics, $extra);
+    }
+}

--- a/app/Jobs/CreateVatusaSoloCert.php
+++ b/app/Jobs/CreateVatusaSoloCert.php
@@ -35,9 +35,19 @@ class CreateVatusaSoloCert implements ShouldQueue
         ]);
 
         if ($request->failed()) {
-            Log::error('Failed to push solo cert to VATUSA for user '.$this->soloCert->user_id.'. Response: '.$request->body());
+            Log::error('Failed to push solo cert to VATUSA', [
+                'solo_cert_id' => $this->soloCert->id,
+                'user_id' => $this->soloCert->user_id,
+                'position' => $this->soloCert->position,
+                'status' => $request->status(),
+                'body' => $request->body(),
+            ]);
         } else {
-            Log::info('Successfully pushed solo cert to VATUSA for user '.$this->soloCert->user_id);
+            Log::info('Pushed solo cert to VATUSA', [
+                'solo_cert_id' => $this->soloCert->id,
+                'user_id' => $this->soloCert->user_id,
+                'position' => $this->soloCert->position,
+            ]);
         }
     }
 }

--- a/app/Jobs/RevokeVatusaSoloCert.php
+++ b/app/Jobs/RevokeVatusaSoloCert.php
@@ -37,9 +37,19 @@ class RevokeVatusaSoloCert implements ShouldQueue
         ]);
 
         if ($request->failed()) {
-            Log::error('Failed to revoke solo cert from VATUSA for user '.$this->soloCert->user_id, ['response' => $request->body()]);
+            Log::error('Failed to revoke solo cert from VATUSA', [
+                'solo_cert_id' => $this->soloCert->id,
+                'user_id' => $this->soloCert->user_id,
+                'position' => $this->soloCert->position,
+                'status' => $request->status(),
+                'body' => $request->body(),
+            ]);
         } else {
-            Log::info('Successfully revoked solo cert from VATUSA for user '.$this->soloCert->user_id);
+            Log::info('Revoked solo cert from VATUSA', [
+                'solo_cert_id' => $this->soloCert->id,
+                'user_id' => $this->soloCert->user_id,
+                'position' => $this->soloCert->position,
+            ]);
         }
     }
 }

--- a/app/Jobs/SyncRoster.php
+++ b/app/Jobs/SyncRoster.php
@@ -5,17 +5,18 @@ namespace App\Jobs;
 use App;
 use App\DTOs\VatusaFacilityInfoDTO;
 use App\DTOs\VatusaRosterUser;
+use App\Jobs\Concerns\LogsJobRun;
 use App\Models\Staff;
 use App\Models\User;
+use App\Support\PrivilegedAction;
 use Http;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Support\Facades\Log;
 
 class SyncRoster implements ShouldBeUnique, ShouldQueue
 {
-    use Queueable;
+    use LogsJobRun, Queueable;
 
     /**
      * Create a new job instance.
@@ -26,6 +27,8 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     {
         $ROSTER_API_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility').'/roster/both';
 
+        $this->runDebug('fetching roster from VATUSA', ['endpoint' => $ROSTER_API_ENDPOINT]);
+
         $rosterData = Http::get($ROSTER_API_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
@@ -35,6 +38,11 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
         }
 
         $roster = $rosterData->json();
+
+        // Snapshot membership before the sync so we can report who joined and
+        // who left, rather than just "the sync ran".
+        $before = User::where('rostered', true)->pluck('id')->all();
+
         User::where(['rostered' => true])->update(['rostered' => false]);
 
         for ($i = 0; $i < count($roster['data']); $i++) {
@@ -43,12 +51,47 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
             User::updateFromVatusa($vatusaUser);
         }
 
+        $after = User::where('rostered', true)->pluck('id')->all();
+
+        $joined = array_values(array_diff($after, $before));
+        $departed = array_values(array_diff($before, $after));
+
+        $this->setMetric('roster_size_reported', count($roster['data']));
+        $this->setMetric('roster_size_stored', count($after));
+        $this->setMetric('controllers_joined', count($joined));
+        $this->setMetric('controllers_departed', count($departed));
+
+        $this->runDebug('roster membership diff', [
+            'joined_cids' => $joined,
+            'departed_cids' => $departed,
+        ]);
+
+        $this->recordRosterDepartures($departed);
+
         // Clear hanging OIs
         User::where([
             'rostered' => false,
         ])->update([
             'operating_initials' => null,
         ]);
+    }
+
+    /**
+     * A controller dropping off the roster is a membership removal, so it goes
+     * in the audit trail alongside staff-initiated removals — with no causer,
+     * since VATUSA rather than a staff member made the call.
+     *
+     * @param  array<int, int>  $departedCids
+     */
+    private function recordRosterDepartures(array $departedCids): void
+    {
+        foreach (User::whereIn('id', $departedCids)->get() as $user) {
+            PrivilegedAction::record(PrivilegedAction::ROSTER_USER_REMOVED, $user, [
+                'cid' => $user->id,
+                'name' => $user->name,
+                'reason' => 'no longer present on the VATUSA roster',
+            ]);
+        }
     }
 
     private function syncRosteredRole()
@@ -62,6 +105,9 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
                 $user->removeRole('rostered');
             }
         }
+
+        $this->setMetric('rostered_role_synced', $users->count());
+        $this->runDebug('rostered role synced');
     }
 
     private function clearUserRoles()
@@ -77,8 +123,22 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     {
         $staffMembers = Staff::all();
 
+        $this->setMetric('staff_positions', $staffMembers->count());
+
         foreach ($staffMembers as $staff) {
             $user = $staff->user;
+
+            if (! $user) {
+                $this->runWarning('staff position references a user not on the roster', [
+                    'title' => $staff->title_short,
+                    'cid' => $staff->user_id,
+                ]);
+            }
+
+            $this->runDebug('assigning staff roles', [
+                'cid' => $staff->user_id,
+                'title' => $staff->title_short,
+            ]);
 
             switch ($staff->title_short) {
                 case 'ATM':
@@ -111,6 +171,8 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     private function updateStaffMembers()
     {
         $FACILITY_INFO_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility');
+        $this->runDebug('fetching facility info from VATUSA', ['endpoint' => $FACILITY_INFO_ENDPOINT]);
+
         $facilityInfo = Http::get($FACILITY_INFO_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
@@ -134,6 +196,8 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
      */
     public function handle(): void
     {
+        $this->startRun(['facility' => config('app.vatusa_facility')]);
+
         try {
             $this->updateRoster();
 
@@ -155,13 +219,11 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
 
             $this->syncRosteredRole();
 
-            Log::info('Roster sync completed successfully.');
+            $this->finishRun();
         } catch (\Exception $e) {
-            // Log error
-            Log::error('Error syncing roster: '.$e->getMessage().'\n'.$e->getTraceAsString(), [
+            $this->failRun($e, [
                 'url' => config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility'),
                 'environment' => App::environment(),
-                'exception' => get_class($e),
             ]);
         }
     }

--- a/app/Jobs/SyncStatsimSessions.php
+++ b/app/Jobs/SyncStatsimSessions.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Jobs\Concerns\LogsJobRun;
 use App\Models\ControllerMonthlyStat;
 use App\Models\ControllerSession;
 use App\Models\StatisticsPrefixes;
@@ -10,12 +11,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class SyncStatsimSessions implements ShouldQueue
 {
-    use Queueable;
+    use LogsJobRun, Queueable;
 
     public int $timeout = 300;
 
@@ -26,6 +26,12 @@ class SyncStatsimSessions implements ShouldQueue
         $from = Carbon::create($this->year, $this->month, 1)->startOfMonth();
         $to = $from->copy()->endOfMonth();
 
+        $this->startRun([
+            'year' => $this->year,
+            'month' => $this->month,
+            'range' => $from->toDateString().' to '.$to->toDateString(),
+        ]);
+
         $response = Http::timeout(60)
             ->withHeaders(['X-Api-Key' => config('app.statsim_api_key') ?? ''])
             ->get('https://api.statsim.net/api/atcsessions/dates', [
@@ -34,7 +40,7 @@ class SyncStatsimSessions implements ShouldQueue
             ]);
 
         if (! $response->successful()) {
-            Log::error('Statsim sync failed', [
+            $this->abortRun('Statsim API request failed', [
                 'status' => $response->status(),
                 'body' => Str::limit($response->body(), 500),
                 'year' => $this->year,
@@ -46,7 +52,10 @@ class SyncStatsimSessions implements ShouldQueue
 
         $sessions = $response->json() ?? [];
         if (! is_array($sessions)) {
-            Log::error('Statsim sync returned non-array payload', ['year' => $this->year, 'month' => $this->month]);
+            $this->abortRun('Statsim returned a non-array payload', [
+                'year' => $this->year,
+                'month' => $this->month,
+            ]);
 
             return;
         }
@@ -54,6 +63,12 @@ class SyncStatsimSessions implements ShouldQueue
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         $rosteredCids = User::where('rostered', true)->pluck('id')->flip();
         $touchedUserIds = [];
+
+        $this->setMetric('sessions_received', count($sessions));
+        $this->runDebug('fetched sessions', [
+            'prefixes' => $prefixes,
+            'rostered_controllers' => $rosteredCids->count(),
+        ]);
 
         foreach ($sessions as $session) {
             $callsign = $session['callsign'] ?? null;
@@ -63,20 +78,28 @@ class SyncStatsimSessions implements ShouldQueue
             $loggedOff = $session['loggedOff'] ?? null;
 
             if (! $callsign || ! $vatsimId || ! $sessionId || ! $loggedOn || ! $loggedOff) {
+                $this->countMetric('skipped_incomplete');
+
                 continue;
             }
 
             if (! Str::startsWith($callsign, $prefixes)) {
+                $this->countMetric('skipped_foreign_prefix');
+
                 continue;
             }
 
             $userId = (int) $vatsimId;
             if (! $rosteredCids->has($userId)) {
+                $this->countMetric('skipped_unrostered');
+
                 continue;
             }
 
             $facilityLevel = $this->facilityLevel(Str::upper(Str::substr($callsign, -3)));
             if ($facilityLevel < 2) {
+                $this->countMetric('skipped_unrated_position');
+
                 continue;
             }
 
@@ -91,12 +114,16 @@ class SyncStatsimSessions implements ShouldQueue
                 ]
             );
 
+            $this->countMetric('sessions_stored');
             $touchedUserIds[$userId] = true;
         }
 
         foreach (array_keys($touchedUserIds) as $userId) {
             $this->recomputeMonthlyStats($userId, $this->year, $this->month);
+            $this->countMetric('controllers_recomputed');
         }
+
+        $this->finishRun(['year' => $this->year, 'month' => $this->month]);
     }
 
     private function facilityLevel(string $suffix): int

--- a/app/Jobs/SyncTrainingTickets.php
+++ b/app/Jobs/SyncTrainingTickets.php
@@ -2,17 +2,17 @@
 
 namespace App\Jobs;
 
+use App\Jobs\Concerns\LogsJobRun;
 use App\Models\TrainingTicket;
 use DateTime;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 
 class SyncTrainingTickets implements ShouldQueue
 {
-    use Queueable;
+    use LogsJobRun, Queueable;
 
     /**
      * Create a new job instance.
@@ -28,11 +28,17 @@ class SyncTrainingTickets implements ShouldQueue
     public function handle(): void
     {
         // https://api.vatusa.net/v2/training/record/{recordID}
-        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false]);
+        $this->startRun();
 
-        foreach ($unsyncedTickets->get() as $ticket) {
+        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false])->get();
+
+        $this->setMetric('tickets_pending', $unsyncedTickets->count());
+
+        foreach ($unsyncedTickets as $ticket) {
             $this->createVatusaTrainingTicket($ticket);
         }
+
+        $this->finishRun();
     }
 
     private function createVatusaTrainingTicket(mixed $ticket)
@@ -52,16 +58,19 @@ class SyncTrainingTickets implements ShouldQueue
                 'location' => $ticket->location,
             ]);
         } catch (Exception $e) {
-            Log::error($e->getMessage());
+            $this->countMetric('tickets_errored');
+            $this->failRun($e, ['ticket_id' => $ticket->id, 'user_id' => $ticket->user_id]);
 
             return;
         }
 
         if (! isset($request) || ! $request->successful()) {
-            Log::warning('Vatusa training record create failed', [
+            $this->countMetric('tickets_rejected');
+            $this->runWarning('VATUSA rejected a training record', [
                 'status' => isset($request) ? $request->status() : null,
                 'body' => isset($request) ? $request->body() : null,
                 'ticket_id' => $ticket->id,
+                'user_id' => $ticket->user_id,
             ]);
 
             return;
@@ -87,5 +96,19 @@ class SyncTrainingTickets implements ShouldQueue
         $ticket->vatusa_synced = true;
         $ticket->vatusa_id = $vatusaId ? (string) $vatusaId : substr(preg_replace('/[^a-z0-9]/i', '', sha1($request->body() ?? (string) microtime(true))), 0, 12);
         $ticket->save();
+
+        if (! $vatusaId) {
+            $this->countMetric('tickets_synced_without_vatusa_id');
+            $this->runWarning('VATUSA accepted a training record but returned no record ID', [
+                'ticket_id' => $ticket->id,
+                'fallback_vatusa_id' => $ticket->vatusa_id,
+            ]);
+        }
+
+        $this->countMetric('tickets_synced');
+        $this->runDebug('training record synced', [
+            'ticket_id' => $ticket->id,
+            'vatusa_id' => $ticket->vatusa_id,
+        ]);
     }
 }

--- a/app/Jobs/UpdateOnlineControllers.php
+++ b/app/Jobs/UpdateOnlineControllers.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\DTOs\OnlineControllerDTO;
+use App\Jobs\Concerns\LogsJobRun;
 use App\Models\OnlineController;
 use App\Models\StatisticsPrefixes;
 use Http;
@@ -12,12 +13,22 @@ use Str;
 
 class UpdateOnlineControllers implements ShouldQueue
 {
-    use Queueable;
+    use LogsJobRun, Queueable;
 
     /**
      * Create a new job instance.
      */
     public function __construct() {}
+
+    /**
+     * This job runs every minute, so a per-run info line would be ~1,400 lines
+     * a day of "nothing happened". The summary drops to debug; anything that
+     * actually goes wrong is still warned or errored at full volume.
+     */
+    protected function jobRunCompletionLevel(): string
+    {
+        return 'debug';
+    }
 
     /**
      * Execute the job.
@@ -26,17 +37,45 @@ class UpdateOnlineControllers implements ShouldQueue
     {
         $API_ENDPOINT = config('app.vatsim_api_url').'/v2/atc/online';
 
+        $this->startRun();
+
         $onlineData = Http::get($API_ENDPOINT);
 
-        $controllers = json_decode($onlineData, true);
+        if ($onlineData->failed()) {
+            $this->abortRun('VATSIM online-controller request failed', [
+                'endpoint' => $API_ENDPOINT,
+                'status' => $onlineData->status(),
+                'body' => Str::limit($onlineData->body(), 500),
+            ]);
+
+            return;
+        }
+
+        $controllers = $onlineData->json();
+
+        if (! is_array($controllers)) {
+            $this->abortRun('VATSIM returned a non-array payload', [
+                'endpoint' => $API_ENDPOINT,
+                'body' => Str::limit($onlineData->body(), 500),
+            ]);
+
+            return;
+        }
+
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         OnlineController::truncate();
+
+        $this->setMetric('controllers_online_network', count($controllers));
 
         foreach ($controllers as $controller) {
             $onlineController = new OnlineControllerDTO($controller);
             if (Str::startsWith($onlineController->callsign, $prefixes)) {
                 OnlineController::fromDTO($onlineController);
+                $this->countMetric('controllers_online_facility');
+                $this->runDebug('facility controller online', ['callsign' => $onlineController->callsign]);
             }
         }
+
+        $this->finishRun();
     }
 }

--- a/app/Support/PrivilegedAction.php
+++ b/app/Support/PrivilegedAction.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Records a privileged ("sudo") staff action to both audit trails:
+ *
+ *  1. The `activity_log` table, so the action shows up in the admin audit-log
+ *     viewer alongside model changes (see docs/systems/audit-logging.md).
+ *  2. The application log at info level, so it is present in whatever the
+ *     `LOG_STACK` is shipping to (file, Discord, syslog, ...) even if the
+ *     database is later lost or rolled back.
+ *
+ * Use this for actions that change someone *else's* standing at the facility —
+ * visitor acceptances/denials, roster removals, solo cert issue/revoke,
+ * training assignment changes, and deletions of admin-managed records.
+ */
+final class PrivilegedAction
+{
+    /**
+     * Action name constants. These become the activity `event` value, which is
+     * what the audit-log viewer renders as the action badge, so keep them
+     * short, lowercase and dot-namespaced.
+     */
+    public const VISITOR_REQUEST_APPROVED = 'visitor.approved';
+
+    public const VISITOR_REQUEST_DENIED = 'visitor.denied';
+
+    public const VISITOR_REQUEST_SUBMITTED = 'visitor.submitted';
+
+    public const SOLO_CERT_ISSUED = 'solo-cert.issued';
+
+    public const SOLO_CERT_REVOKED = 'solo-cert.revoked';
+
+    public const TRAINING_ASSIGNMENT_UPDATED = 'training-assignment.updated';
+
+    public const TRAINING_ASSIGNMENT_CLAIMED = 'training-assignment.claimed';
+
+    public const TRAINING_ASSIGNMENT_DROPPED = 'training-assignment.dropped';
+
+    public const TRAINING_ASSIGNMENT_FORFEITED = 'training-assignment.forfeited';
+
+    public const CONTRIBUTOR_ADDED = 'contributor.added';
+
+    public const CONTRIBUTOR_REMOVED = 'contributor.removed';
+
+    public const STATISTICS_SYNC_QUEUED = 'statistics.sync-queued';
+
+    public const ROSTER_USER_REMOVED = 'roster.user-removed';
+
+    /**
+     * Record a privileged action.
+     *
+     * @param  string  $action  One of the constants above (the activity `event`).
+     * @param  Model|null  $subject  The record the action was performed on, if any.
+     * @param  array<string, mixed>  $properties  Action detail rendered in the audit-log viewer.
+     * @param  Model|null  $actor  Overrides the authenticated user; pass explicitly
+     *                             for actions taken by a job or console command.
+     */
+    public static function record(
+        string $action,
+        ?Model $subject = null,
+        array $properties = [],
+        ?Model $actor = null,
+    ): void {
+        $actor ??= Auth::user();
+        $context = self::requestContext();
+
+        self::recordToActivityLog($action, $subject, $properties, $actor, $context);
+
+        Log::info("privileged action: {$action}", array_merge([
+            'action' => $action,
+            'actor_cid' => $actor?->getKey(),
+            'actor_name' => $actor->name ?? null,
+            'subject_type' => $subject ? class_basename($subject) : null,
+            'subject_id' => $subject?->getKey(),
+        ], $properties, $context));
+    }
+
+    /**
+     * Write the activity_log row.
+     *
+     * The write is deliberately non-fatal: an audit-log failure must not turn a
+     * successful staff action into a 500. If it fails we escalate to `critical`
+     * on the application log so the gap in the database trail is itself visible.
+     *
+     * @param  array<string, mixed>  $properties
+     * @param  array<string, mixed>  $context
+     */
+    private static function recordToActivityLog(
+        string $action,
+        ?Model $subject,
+        array $properties,
+        ?Model $actor,
+        array $context,
+    ): void {
+        try {
+            $activity = activity()->event($action)->withProperties([
+                // The viewer and CSV export read `attributes`, so action detail
+                // goes there; request metadata is kept separate to avoid
+                // cluttering every row with IPs and route names.
+                'attributes' => $properties,
+                'context' => $context,
+            ]);
+
+            if ($actor) {
+                $activity->causedBy($actor);
+            }
+
+            if ($subject) {
+                $activity->performedOn($subject);
+            }
+
+            $activity->log($action);
+        } catch (Throwable $e) {
+            Log::critical("Failed to write privileged action to the audit log: {$action}", [
+                'action' => $action,
+                'actor_cid' => $actor?->getKey(),
+                'subject_type' => $subject ? class_basename($subject) : null,
+                'subject_id' => $subject?->getKey(),
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Forensic metadata about where the action came from.
+     *
+     * Presence of a resolved route — rather than `runningInConsole()` — is what
+     * distinguishes a real HTTP request from a console command or queue worker.
+     * A worker still has a `request()` instance, but it has no route, and
+     * `runningInConsole()` is true under the test runner even for HTTP tests.
+     *
+     * @return array<string, mixed>
+     */
+    private static function requestContext(): array
+    {
+        $request = request();
+        $route = $request->route();
+
+        if ($route === null) {
+            return ['source' => 'console'];
+        }
+
+        return [
+            'source' => 'web',
+            'ip' => $request->ip(),
+            'route' => $route->getName() ?? $request->path(),
+            'method' => $request->method(),
+        ];
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -80,6 +80,26 @@ return [
             'replace_placeholders' => true,
         ],
 
+        /*
+        | Always-on debug channel.
+        |
+        | Add this to LOG_STACK to capture debug output (job phase logging,
+        | roster sync detail) in its own rotating file without turning the
+        | main channel down to debug and flooding it. Kept short by default
+        | because debug output is high volume:
+        |
+        |     LOG_STACK=daily,debug
+        |
+        | See docs/systems/logging.md.
+        */
+        'debug' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/debug.log'),
+            'level' => 'debug',
+            'days' => env('LOG_DEBUG_DAYS', 3),
+            'replace_placeholders' => true,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ The site is a VATSIM ARTCC web app built on a conventional server-rendered Larav
 | Auth | Laravel Socialite (VATSIM Connect) | Custom Socialite provider; see [authentication](authentication-authorization.md). |
 | Authorization | `spatie/laravel-permission` | Roles and permissions, enforced with middleware aliases. |
 | Audit logging | `spatie/laravel-activitylog` | See [audit logging](systems/audit-logging.md). |
+| Application logging | Monolog (Laravel `Log`) | Job run summaries, privileged actions, debug mode. See [logging](systems/logging.md). |
 | Search | Laravel Scout | Uses the default `collection` driver (see [Infrastructure drivers](#infrastructure-drivers)). |
 | Testing | Pest 4 (`pestphp/pest: ^4.1`) | With `pest-plugin-laravel` and `pest-plugin-stressless`. |
 
@@ -130,11 +131,18 @@ The scheduler is defined in `routes/console.php` (the console entry registered b
 | --- | --- | --- |
 | `Schedule::job(new SyncRoster())` | `app/Jobs/SyncRoster.php` | Every two hours |
 | `Schedule::job(new UpdateOnlineControllers())` | `app/Jobs/UpdateOnlineControllers.php` | Every minute |
+| `Schedule::call(...)` (named `statsim-sync`) | `app/Jobs/SyncStatsimSessions.php` | Daily at 04:00, for the current and previous month |
 
 `SyncRoster` pulls the controller roster from VATUSA; `UpdateOnlineControllers` refreshes
-who is currently online. Both are covered in [VATSIM integration](vatsim-integration.md)
+who is currently online; `SyncStatsimSessions` backfills controller session statistics.
+The first two are covered in [VATSIM integration](vatsim-integration.md)
 and [roster and membership](systems/roster-and-membership.md). In local/development you can
 trigger these manually via the dev-only `/sync` route.
+
+Every scheduled job emits a run summary — duration and per-run counters — on
+success as well as on failure, so a job that silently stopped running can be
+told apart from one that ran and found nothing to do. See
+[logging](systems/logging.md#job-run-logging).
 
 Because scheduled work is dispatched as queued jobs, a queue worker and the scheduler both
 need to run. `composer run dev` starts `php artisan serve`, `php artisan queue:listen`,
@@ -179,4 +187,5 @@ Each subsystem has its own document. Start here and follow the links:
 | [systems/certifications.md](systems/certifications.md) | Certification facilities, levels, and user certifications. |
 | [systems/users-and-profiles.md](systems/users-and-profiles.md) | User accounts, profiles, and staff directory. |
 | [systems/audit-logging.md](systems/audit-logging.md) | Activity logging with `spatie/laravel-activitylog`. |
+| [systems/logging.md](systems/logging.md) | Application logging: job run summaries, privileged staff actions, and debug mode. |
 | [discrepancies.md](discrepancies.md) | Known inconsistencies, dead code, and follow-ups found while documenting. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,20 @@ files (`config/app.php`, `config/logging.php`, `config/mail.php`) but are not pr
 ### Logging
 
 - `LOG_CHANNEL`, `LOG_STACK`, `LOG_DEPRECATIONS_CHANNEL`, `LOG_LEVEL` — log routing and
-  verbosity.
+  verbosity. Run production at `LOG_LEVEL=info`; scheduled jobs emit their run
+  summaries at that level.
+- `LOG_DAILY_DAYS` — retention for the `daily` channel (default 14).
+- `LOG_DEBUG_DAYS` — retention for the `debug` channel (default 3).
+
+To troubleshoot a sync in production, add the dedicated debug channel rather
+than turning the main log down:
+
+```dotenv
+LOG_STACK=daily,discord,debug
+```
+
+That captures debug output in `storage/logs/debug.log` on a short rotation while
+the main log stays at `info`. See [logging](systems/logging.md#debug-logging).
 
 ### Database
 

--- a/docs/systems/audit-logging.md
+++ b/docs/systems/audit-logging.md
@@ -7,6 +7,9 @@ changes using `spatie/laravel-activitylog`, and how staff view and export that
 trail from the admin area. It is written for developers and contributors who
 need to add auditing to a model or work on the audit-log viewer.
 
+For the application log — scheduled-job run logging, debug logging, and the
+channels they are written to — see [logging.md](logging.md).
+
 ## Key concepts
 
 - **Activity log entries** are rows in the `activity_log` table, each capturing a
@@ -17,6 +20,12 @@ need to add auditing to a model or work on the audit-log viewer.
   `Spatie\Activitylog\Traits\LogsActivity` trait and defining
   `getActivitylogOptions()`, which declares exactly which attributes to log via
   `LogOptions::defaults()->logOnly([...])`.
+- **Privileged staff actions are recorded explicitly**, not via a model trait,
+  by `App\Support\PrivilegedAction::record()`. These entries use a custom
+  `event` (`visitor.approved`, `solo-cert.revoked`, …) rather than
+  created/updated/deleted, and appear in the same viewer. See
+  [logging.md](logging.md#privileged-action-logging) for the full list and how
+  to add one.
 - **The viewer is admin-only** and lets staff filter by controller (CID) and by
   record type, then either browse the paginated log or stream a CSV export.
 
@@ -30,9 +39,24 @@ need to add auditing to a model or work on the audit-log viewer.
 | `TrainingAssignment` | `app/Models/TrainingAssignment.php` | `user_id`, `instructor_id`, `status` |
 | `TrainingTicket` | `app/Models/TrainingTicket.php` | `user_id`, `instructor_id`, `session_date`, `duration`, `movements`, `score`, `notes`, `location`, `ots_status` |
 | `StatisticsPrefixes` | `app/Models/StatisticsPrefixes.php` | `name` |
+| `Publication` | `app/Models/Publication.php` | `name`, `description`, `version`, `publication_category_id`, `original_filename` |
+| `PublicationCategory` | `app/Models/PublicationCategory.php` | `title`, `description`, `display_order`, `show_in_nav` |
 
-All four use `LogOptions::defaults()`, so only the listed attributes are logged
-and (by Spatie's defaults) empty diffs are not recorded.
+All use `LogOptions::defaults()`, so only the listed attributes are logged and
+(by Spatie's defaults) empty diffs are not recorded. The two publication models
+additionally call `logOnlyDirty()`.
+
+### Privileged action entries
+
+Entries written by `App\Support\PrivilegedAction` share the same table but are
+shaped slightly differently:
+
+- `event` is the action name (e.g. `visitor.approved`), so the viewer's badge
+  falls through its `match` to `badge-ghost`.
+- `properties['attributes']` holds the detail passed at the call site and is
+  rendered as `Field: value` (there is no `old`, since these are not diffs).
+- `properties['context']` holds request metadata — `source`, `ip`, `route`,
+  `method` — which is stored but **not** rendered by the viewer or export.
 
 ### The `activity_log` table
 
@@ -120,6 +144,7 @@ So a viewer must have both `view dashboard` and `view audit logs`.
 | `app/Models/TrainingAssignment.php` | `getActivitylogOptions()` for training assignments |
 | `app/Models/TrainingTicket.php` | `getActivitylogOptions()` for training tickets |
 | `app/Models/StatisticsPrefixes.php` | `getActivitylogOptions()` for statistics prefixes |
+| `app/Support/PrivilegedAction.php` | Records privileged staff actions to this table and the application log |
 | `database/migrations/2025_11_11_035813_create_activity_log_table.php` | Base `activity_log` table |
 | `database/migrations/2025_11_11_035814_add_event_column_to_activity_log_table.php` | Adds `event` column |
 | `database/migrations/2025_11_11_035815_add_batch_uuid_column_to_activity_log_table.php` | Adds `batch_uuid` column |
@@ -140,3 +165,7 @@ So a viewer must have both `view dashboard` and `view audit logs`.
   user as subject/causer.
 - **Timestamps are emitted in UTC/Zulu** in the export (`created_at->utc()`),
   regardless of the app timezone.
+- **Privileged action entries are best-effort.** `PrivilegedAction` swallows a
+  failed `activity_log` write so the staff action itself still succeeds, logging
+  the miss at `critical` to the application log. The database trail can
+  therefore have gaps that the application log does not.

--- a/docs/systems/logging.md
+++ b/docs/systems/logging.md
@@ -1,0 +1,242 @@
+# Logging
+
+## Purpose
+
+This document describes how the ZJX ARTCC site logs what it is doing, so that
+site reliability can be monitored and staff actions can be traced after the
+fact. It covers the three kinds of logging in the app and how to turn up the
+detail when something needs investigating.
+
+For the database-backed audit trail and its admin viewer, see
+[audit-logging.md](audit-logging.md); this document covers the application log
+and how the two fit together.
+
+## Key concepts
+
+The app writes three distinct kinds of log:
+
+| Kind | Where it goes | What it answers |
+| --- | --- | --- |
+| **Job run logs** | Application log | Did the scheduled job run, how long did it take, and what did it do? |
+| **Privileged action logs** | `activity_log` table **and** application log | Which staff member did what to whom, and from where? |
+| **Debug logs** | Application log, only at `LOG_LEVEL=debug` | Why is a sync behaving the way it is? |
+
+Two rules shape the design:
+
+- **Success is logged, not just failure.** A job that only logs on error is
+  indistinguishable from a job that never ran. Every scheduled job emits a
+  summary line when it completes, even when it changed nothing.
+- **Privileged actions are written twice.** The database trail powers the admin
+  viewer; the application-log copy survives a database loss or rollback.
+
+## Job run logging
+
+`App\Jobs\Concerns\LogsJobRun` gives a job a consistent run log. A job that uses
+it emits:
+
+| Line | Level | When |
+| --- | --- | --- |
+| `<Job> started` | `debug` | `startRun()` |
+| `<Job>: <message>` | `debug` | `runDebug()`, per phase |
+| `<Job>: <message>` | `warning` | `runWarning()` |
+| `<Job> completed` | `info` (overridable) | `finishRun()` |
+| `<Job> aborted: <reason>` | `error` | `abortRun()` — a known bad outcome, e.g. an upstream 5xx |
+| `<Job> failed: <message>` | `error` | `failRun()` — an exception, with class, origin and trace |
+
+Every line of a run carries the same `run_id` (a UUID) plus `job` and
+`duration_ms`, so one run can be isolated even when runs overlap:
+
+```
+grep '"run_id":"0193f0c2-…"' storage/logs/laravel.log
+```
+
+### Metrics
+
+`countMetric('key')` increments a counter and `setMetric('key', $value)` sets
+one; both are merged into the context of every subsequent line, and in
+particular into the completion summary. That summary is the thing to watch for
+reliability monitoring — for example, a Statsim run reports:
+
+```
+SyncStatsimSessions completed {"job":"App\\Jobs\\SyncStatsimSessions",
+  "run_id":"…","duration_ms":812.4,"sessions_received":143,
+  "sessions_stored":97,"skipped_unrostered":31,"skipped_foreign_prefix":15,
+  "controllers_recomputed":22,"year":2026,"month":8}
+```
+
+### Instrumented jobs
+
+| Job | Schedule | Completion level | Key metrics |
+| --- | --- | --- | --- |
+| `SyncRoster` | every 2 hours | `info` | `roster_size_reported`, `roster_size_stored`, `controllers_joined`, `controllers_departed`, `staff_positions` |
+| `SyncStatsimSessions` | daily 04:00 (current + previous month) | `info` | `sessions_received`, `sessions_stored`, `skipped_*`, `controllers_recomputed` |
+| `SyncTrainingTickets` | on demand | `info` | `tickets_pending`, `tickets_synced`, `tickets_rejected`, `tickets_errored` |
+| `UpdateOnlineControllers` | every minute | `debug` | `controllers_online_network`, `controllers_online_facility` |
+
+`UpdateOnlineControllers` overrides `jobRunCompletionLevel()` to `debug`
+because it runs every minute; at `info` it would add ~1,400 lines a day saying
+nothing happened. Its failures are still logged at `error`.
+
+The single-shot VATUSA jobs (`AddUserToVisitingRoster`, `CreateVatusaSoloCert`,
+`RevokeVatusaSoloCert`) do not use the trait — they are one API call each — but
+they log structured context (`user_id`, `position`, `status`, `body`) rather
+than interpolated strings.
+
+## Privileged action logging
+
+`App\Support\PrivilegedAction::record()` records a staff action that changes
+someone else's standing at the facility. One call writes both trails:
+
+```php
+PrivilegedAction::record(PrivilegedAction::VISITOR_REQUEST_APPROVED, $visitRequest, [
+    'cid' => $visitRequest->user_id,
+    'operating_initials' => 'AB',
+]);
+```
+
+- **`activity_log`** — `event` is the action name, `causer` is the authenticated
+  user, `subject` is the model passed in, and `properties` holds
+  `attributes` (the array you passed, rendered by the audit viewer and CSV
+  export) and `context` (request metadata: `source`, `ip`, `route`, `method`).
+- **Application log** — one `info` line, `privileged action: <action>`, with the
+  same detail flattened into the log context.
+
+### Recorded actions
+
+| Constant | Action name | Recorded in |
+| --- | --- | --- |
+| `VISITOR_REQUEST_SUBMITTED` | `visitor.submitted` | `VisitFacilityController@store` |
+| `VISITOR_REQUEST_APPROVED` | `visitor.approved` | `VisitFacilityController@approve` |
+| `VISITOR_REQUEST_DENIED` | `visitor.denied` | `VisitFacilityController@deny` |
+| `SOLO_CERT_ISSUED` | `solo-cert.issued` | `SoloCertController@store` |
+| `SOLO_CERT_REVOKED` | `solo-cert.revoked` | `SoloCertController@destroy` |
+| `TRAINING_ASSIGNMENT_UPDATED` | `training-assignment.updated` | `TrainingAssignmentController@update` |
+| `TRAINING_ASSIGNMENT_CLAIMED` | `training-assignment.claimed` | `TrainingAssignmentController@claim` |
+| `TRAINING_ASSIGNMENT_DROPPED` | `training-assignment.dropped` | `TrainingAssignmentController@drop` |
+| `TRAINING_ASSIGNMENT_FORFEITED` | `training-assignment.forfeited` | `TrainingAssignmentController@destroy` |
+| `CONTRIBUTOR_ADDED` | `contributor.added` | `ManualContributorController@store` |
+| `CONTRIBUTOR_REMOVED` | `contributor.removed` | `ManualContributorController@destroy` |
+| `STATISTICS_SYNC_QUEUED` | `statistics.sync-queued` | `StatisticsController@sync` |
+| `ROSTER_USER_REMOVED` | `roster.user-removed` | `SyncRoster` (no causer — VATUSA dropped them) |
+
+### Adding a new one
+
+1. Add a constant to `PrivilegedAction` (lowercase, dot-namespaced — it is
+   rendered verbatim as the action badge in the viewer).
+2. Call `PrivilegedAction::record()` *after* the change has been persisted, so a
+   failed action is not recorded as a successful one.
+3. For deletions, snapshot the attributes **before** deleting; afterwards there
+   is nothing left to describe.
+4. Add a row to the table above.
+
+## Debug logging
+
+Debug output is off in normal operation. There are two ways to turn it on.
+
+**Turn the whole log down to debug** — simplest, noisiest:
+
+```dotenv
+LOG_LEVEL=debug
+```
+
+**Add the dedicated `debug` channel** — keeps the main log readable and puts
+debug output in its own short-retention file at `storage/logs/debug.log`:
+
+```dotenv
+LOG_STACK=daily,debug
+LOG_DEBUG_DAYS=3
+```
+
+The `debug` channel is pinned at debug level regardless of `LOG_LEVEL`, so the
+main channel can stay at `info` while debug detail is captured separately.
+
+### What debug logging gives you
+
+`SyncRoster` is the most heavily instrumented, since it is the sync most likely
+to need investigating:
+
+- `fetching roster from VATUSA` / `fetching facility info from VATUSA`, with the
+  endpoint being called
+- `roster membership diff`, with the full `joined_cids` and `departed_cids` lists
+- `assigning staff roles`, per staff position, with CID and title
+- `rostered role synced`
+
+`SyncStatsimSessions` logs the prefixes and rostered-controller count it is
+filtering against; `UpdateOnlineControllers` logs each facility controller found
+online; `SyncTrainingTickets` logs each ticket ID and the VATUSA record ID it
+came back with.
+
+Remember to put `LOG_LEVEL` back to `info` afterwards — the debug channel's
+3-day retention limits the damage, but `LOG_LEVEL=debug` on the main channel
+does not rotate any faster.
+
+## Channels
+
+Configured in `config/logging.php`; the active set is `LOG_STACK`
+(comma-separated) under the `stack` channel.
+
+| Channel | Purpose |
+| --- | --- |
+| `single` | Everything to one file, `storage/logs/laravel.log`. Default. |
+| `daily` | Rotating daily file, retained `LOG_DAILY_DAYS` (default 14). |
+| `debug` | Rotating daily file at `storage/logs/debug.log`, always debug level, retained `LOG_DEBUG_DAYS` (default 3). |
+| `discord` | Ships to a Discord webhook (`LOG_DISCORD_WEBHOOK_URL`). |
+| `stderr` | For containerised deployments where logs are collected from the process. |
+
+A production deployment that wants alerting without noise typically runs
+`LOG_STACK=daily,discord` with `LOG_LEVEL=info`, and temporarily switches to
+`LOG_STACK=daily,discord,debug` while investigating.
+
+## Testing
+
+`tests/Pest.php` provides two helpers:
+
+- `captureLogs()` swaps the logger for a Monolog `TestHandler`, so tests assert
+  on the records that actually came out — level, message and context — rather
+  than on which facade method was called.
+- `findLog($handler, $needle)` returns the first record whose message contains
+  `$needle`, as `['level' => …, 'message' => …, 'context' => …]`.
+
+```php
+$logs = captureLogs();
+
+(new SyncStatsimSessions(2026, 1))->handle();
+
+$completed = findLog($logs, 'SyncStatsimSessions completed');
+expect($completed['level'])->toBe('INFO');
+expect($completed['context']['sessions_stored'])->toBe(1);
+```
+
+Coverage lives in `tests/Feature/JobRunLoggingTest.php` and
+`tests/Feature/PrivilegedActionLoggingTest.php`.
+
+## Key files
+
+| Path | Role |
+| --- | --- |
+| `app/Jobs/Concerns/LogsJobRun.php` | Job run logging trait |
+| `app/Support/PrivilegedAction.php` | Privileged action recorder (dual trail) |
+| `config/logging.php` | Channel definitions, including `debug` |
+| `routes/console.php` | Schedule definitions and dispatch logging |
+| `tests/Pest.php` | `captureLogs()` / `findLog()` helpers |
+
+## Gotchas
+
+- **An audit-log write failure does not fail the action.** `PrivilegedAction`
+  catches a `Throwable` from the `activity_log` write, logs it at `critical`,
+  and lets the staff action succeed. Availability is preferred over a hard
+  audit guarantee, and the application-log copy still records the action — but
+  it does mean the database trail can have gaps. Grep for
+  `Failed to write privileged action` to find them.
+- **`source` is decided by route presence, not `runningInConsole()`.** A queue
+  worker has a `request()` instance but no resolved route, and
+  `runningInConsole()` is true under the test runner even for HTTP tests.
+- **Metrics are merged into every line after they are set**, not just the
+  summary, so a counter read from a mid-run debug line is a running total, not
+  a final one.
+- **`runDebug()` still costs something.** The context array is built even when
+  the debug level is disabled, so avoid expensive computation in the arguments
+  of a per-item debug call inside a hot loop.
+- **Only `properties['attributes']` is rendered** by the audit viewer and CSV
+  export. Request metadata under `properties['context']` is stored but only
+  visible in the database.

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,6 +6,7 @@ use App\Jobs\UpdateOnlineControllers;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
@@ -16,9 +17,21 @@ Schedule::job(new SyncRoster)->everyTwoHours();
 
 Schedule::job(new UpdateOnlineControllers)->everyMinute();
 
+// The current and previous month are both re-synced daily, because Statsim can
+// backfill sessions after the month has rolled over.
 Schedule::call(function () {
     $now = Carbon::now();
-    SyncStatsimSessions::dispatch($now->year, $now->month);
     $prev = $now->copy()->subMonthNoOverflow();
+
+    SyncStatsimSessions::dispatch($now->year, $now->month);
     SyncStatsimSessions::dispatch($prev->year, $prev->month);
-})->dailyAt('04:00');
+
+    Log::info('Queued scheduled Statsim sync', [
+        'months' => [
+            $now->format('Y-m'),
+            $prev->format('Y-m'),
+        ],
+    ]);
+})->dailyAt('04:00')->name('statsim-sync')->onFailure(function () {
+    Log::error('Scheduled Statsim sync failed to dispatch');
+});

--- a/tests/Feature/JobRunLoggingTest.php
+++ b/tests/Feature/JobRunLoggingTest.php
@@ -1,0 +1,345 @@
+<?php
+
+use App\Jobs\SyncRoster;
+use App\Jobs\SyncStatsimSessions;
+use App\Jobs\UpdateOnlineControllers;
+use App\Models\ControllerSession;
+use App\Models\OnlineController;
+use App\Models\StatisticsPrefixes;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Support\Facades\Http;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Build one Statsim API session payload.
+ */
+function statsimSession(array $overrides = []): array
+{
+    return array_merge([
+        'id' => 1,
+        'callsign' => 'JAX_CTR',
+        'vatsimid' => '100',
+        'loggedOn' => '2026-01-05 12:00:00',
+        'loggedOff' => '2026-01-05 14:00:00',
+    ], $overrides);
+}
+
+function fakeStatsim(array $sessions): void
+{
+    Http::fake([
+        'api.statsim.net/*' => Http::response($sessions),
+    ]);
+}
+
+/**
+ * The roster payload shape VATUSA returns, trimmed to what the sync reads.
+ */
+function vatusaRosterEntry(int $cid): array
+{
+    $now = (new DateTime)->format('Y-m-d H:i:s');
+
+    return [
+        'cid' => $cid,
+        'fname' => 'Test',
+        'lname' => 'Controller',
+        'rating' => 6,
+        'email' => "test{$cid}@example.com",
+        'facility' => 'ZJX',
+        'created_at' => $now,
+        'updated_at' => $now,
+        'flag_needbasic' => false,
+        'flag_xferOverride' => false,
+        'facility_join' => $now,
+        'flag_homecontroller' => true,
+        'lastactivity' => $now,
+        'flag_broadcastOptedIn' => false,
+        'flag_preventStaffAssign' => false,
+        'discord_id' => null,
+        'flag_nameprivacy' => false,
+        'last_competency_date' => $now,
+        'promotion_eligible' => false,
+        'transfer_eligible' => false,
+        'roles' => [],
+        'isMentor' => false,
+        'isSupIns' => false,
+        'last_promotion' => $now,
+    ];
+}
+
+beforeEach(function () {
+    // Creating a User assigns the default 'core' role, and the roster sync
+    // assigns 'rostered', so the permission tables must exist in every test.
+    $this->seed(PermissionSeeder::class);
+});
+
+function fakeVatusaRoster(array $cids): void
+{
+    // VatusaFacilityInfoDTO requires every senior-staff slot to be present, so
+    // point them all at the first rostered controller.
+    $staffCid = $cids[0] ?? 100;
+
+    Http::fake([
+        '*/roster/both*' => Http::response([
+            'data' => array_map(fn ($cid) => vatusaRosterEntry($cid), $cids),
+        ]),
+        '*/v2/facility/*' => Http::response([
+            'data' => [
+                'facility' => [
+                    'info' => [
+                        'atm' => $staffCid,
+                        'datm' => $staffCid,
+                        'ta' => $staffCid,
+                        'wm' => $staffCid,
+                        'ec' => $staffCid,
+                        'fe' => $staffCid,
+                    ],
+                    // At least one role is required: VatusaFacilityInfoDTO only
+                    // initialises its typed $roles property inside the loop, so
+                    // an empty list leaves it uninitialised and Staff blows up.
+                    'roles' => [
+                        ['cid' => $staffCid, 'role' => 'ATM', 'created_at' => (new DateTime)->format('Y-m-d H:i:s')],
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+}
+
+// ---------------------------------------------------------------------------
+// The issue's headline complaint: a sync that works silently is a sync you
+// cannot tell apart from a sync that never ran.
+// ---------------------------------------------------------------------------
+
+test('given a statsim sync that succeeds, when it completes, then it logs a summary rather than staying silent', function () {
+    $logs = captureLogs();
+
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+
+    fakeStatsim([statsimSession()]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $completed = findLog($logs, 'SyncStatsimSessions completed');
+
+    expect($completed)->not->toBeNull();
+    expect($completed['level'])->toBe('INFO');
+    expect($completed['context']['sessions_received'])->toBe(1);
+    expect($completed['context']['sessions_stored'])->toBe(1);
+    expect($completed['context']['controllers_recomputed'])->toBe(1);
+    expect($completed['context'])->toHaveKey('duration_ms');
+});
+
+test('given a statsim sync with nothing to do, when it completes, then it still reports the empty run', function () {
+    $logs = captureLogs();
+
+    fakeStatsim([]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $completed = findLog($logs, 'SyncStatsimSessions completed');
+
+    expect($completed)->not->toBeNull();
+    expect($completed['context']['sessions_received'])->toBe(0);
+});
+
+test('given a statsim sync, when sessions are skipped, then the summary says why', function () {
+    $logs = captureLogs();
+
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    // 100 is rostered; 200 is not, and ATL_CTR is another facility's traffic.
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+
+    fakeStatsim([
+        statsimSession(['id' => 1]),
+        statsimSession(['id' => 2, 'vatsimid' => '200']),
+        statsimSession(['id' => 3, 'callsign' => 'ATL_CTR']),
+        statsimSession(['id' => 4, 'loggedOff' => null]),
+    ]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $context = findLog($logs, 'SyncStatsimSessions completed')['context'];
+
+    expect($context['sessions_received'])->toBe(4);
+    expect($context['sessions_stored'])->toBe(1);
+    expect($context['skipped_unrostered'])->toBe(1);
+    expect($context['skipped_foreign_prefix'])->toBe(1);
+    expect($context['skipped_incomplete'])->toBe(1);
+});
+
+test('given the statsim api fails, when the sync runs, then it logs an error with the upstream status', function () {
+    $logs = captureLogs();
+
+    Http::fake(['api.statsim.net/*' => Http::response('upstream exploded', 503)]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $aborted = findLog($logs, 'SyncStatsimSessions aborted');
+
+    expect($aborted)->not->toBeNull();
+    expect($aborted['level'])->toBe('ERROR');
+    expect($aborted['context']['status'])->toBe(503);
+    expect(findLog($logs, 'SyncStatsimSessions completed'))->toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// Correlation + debug logging
+// ---------------------------------------------------------------------------
+
+test('given a job run, when it logs, then every line shares one run id', function () {
+    $logs = captureLogs();
+
+    fakeStatsim([]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $started = findLog($logs, 'SyncStatsimSessions started');
+    $completed = findLog($logs, 'SyncStatsimSessions completed');
+
+    expect($started['level'])->toBe('DEBUG');
+    expect($started['context']['run_id'])->not->toBeEmpty();
+    expect($completed['context']['run_id'])->toBe($started['context']['run_id']);
+});
+
+test('given two runs of the same job, when they log, then their run ids differ', function () {
+    $logs = captureLogs();
+
+    fakeStatsim([]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+    $first = findLog($logs, 'SyncStatsimSessions started')['context']['run_id'];
+
+    $logs->clear();
+
+    (new SyncStatsimSessions(2026, 2))->handle();
+    $second = findLog($logs, 'SyncStatsimSessions started')['context']['run_id'];
+
+    expect($second)->not->toBe($first);
+});
+
+test('given a roster sync, when it runs, then debug logging exposes each phase', function () {
+    $logs = captureLogs();
+
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    expect(findLog($logs, 'fetching roster from VATUSA'))->not->toBeNull();
+    expect(findLog($logs, 'fetching facility info from VATUSA'))->not->toBeNull();
+    expect(findLog($logs, 'roster membership diff'))->not->toBeNull();
+    expect(findLog($logs, 'rostered role synced'))->not->toBeNull();
+});
+
+test('given a roster sync, when it completes, then the summary reports membership counts', function () {
+    $logs = captureLogs();
+
+    User::factory()->create(['id' => 200, 'rostered' => true]);
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    $context = findLog($logs, 'SyncRoster completed')['context'];
+
+    expect($context['roster_size_reported'])->toBe(1);
+    expect($context['controllers_joined'])->toBe(1);
+    expect($context['controllers_departed'])->toBe(1);
+});
+
+test('given the vatusa roster api fails, when the sync runs, then the failure is logged with the exception', function () {
+    $logs = captureLogs();
+
+    Http::fake(['*' => Http::response('nope', 500)]);
+
+    (new SyncRoster)->handle();
+
+    $failed = findLog($logs, 'SyncRoster failed');
+
+    expect($failed)->not->toBeNull();
+    expect($failed['level'])->toBe('ERROR');
+    expect($failed['context'])->toHaveKey('exception');
+    expect($failed['context'])->toHaveKey('origin');
+});
+
+// ---------------------------------------------------------------------------
+// Roster departures are membership removals, so they belong in the audit trail.
+// ---------------------------------------------------------------------------
+
+test('given a controller leaves the roster, when the sync runs, then the removal is recorded in the audit log', function () {
+    $departing = User::factory()->create(['id' => 200, 'rostered' => true]);
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    $entry = Activity::where('event', 'roster.user-removed')->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->subject_id)->toBe($departing->id);
+    // VATUSA dropped them, not a staff member — so there is no causer.
+    expect($entry->causer_id)->toBeNull();
+    expect($entry->properties['attributes']['cid'])->toBe($departing->id);
+});
+
+test('given nobody leaves the roster, when the sync runs, then no removal is recorded', function () {
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    expect(Activity::where('event', 'roster.user-removed')->count())->toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// The every-minute job: quiet on success, loud on failure, and it must not
+// wipe the table when the upstream call fails.
+// ---------------------------------------------------------------------------
+
+test('given the online controller sync succeeds, when it completes, then the summary stays at debug level', function () {
+    $logs = captureLogs();
+
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    Http::fake(['*' => Http::response([
+        ['id' => 100, 'callsign' => 'JAX_CTR', 'start' => now()->toDateTimeString()],
+    ])]);
+
+    (new UpdateOnlineControllers)->handle();
+
+    $completed = findLog($logs, 'UpdateOnlineControllers completed');
+
+    expect($completed)->not->toBeNull();
+    expect($completed['level'])->toBe('DEBUG');
+});
+
+test('given the vatsim api fails, when the online controller sync runs, then it logs an error and keeps the existing rows', function () {
+    $logs = captureLogs();
+
+    OnlineController::create([
+        'callsign' => 'JAX_CTR',
+        'user_id' => 100,
+        'start' => now(),
+    ]);
+
+    Http::fake(['*' => Http::response('gateway timeout', 504)]);
+
+    (new UpdateOnlineControllers)->handle();
+
+    $aborted = findLog($logs, 'UpdateOnlineControllers aborted');
+
+    expect($aborted)->not->toBeNull();
+    expect($aborted['level'])->toBe('ERROR');
+    expect($aborted['context']['status'])->toBe(504);
+    // The old truncate-then-fetch order emptied the table on every upstream blip.
+    expect(OnlineController::count())->toBe(1);
+});
+
+test('given a statsim sync stores sessions, when it finishes, then the sessions are actually persisted', function () {
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+
+    fakeStatsim([statsimSession()]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    expect(ControllerSession::count())->toBe(1);
+});

--- a/tests/Feature/PrivilegedActionLoggingTest.php
+++ b/tests/Feature/PrivilegedActionLoggingTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use App\Enums\VisitRequestStatus;
+use App\Models\ManualContributor;
+use App\Models\User;
+use App\Models\VisitorRequest;
+use App\Support\PrivilegedAction;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Spatie\Activitylog\ActivityLogger;
+use Spatie\Activitylog\Models\Activity;
+
+beforeEach(function () {
+    $this->seed(PermissionSeeder::class);
+    Mail::fake();
+    Queue::fake();
+});
+
+// ---------------------------------------------------------------------------
+// The recorder itself
+// ---------------------------------------------------------------------------
+
+test('given a privileged action, when recorded, then it lands in the activity log with actor, subject and detail', function () {
+    $actor = User::factory()->create();
+    $subject = User::factory()->create();
+
+    $this->actingAs($actor);
+
+    PrivilegedAction::record('test.action', $subject, ['reason' => 'because']);
+
+    $entry = Activity::where('event', 'test.action')->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->causer_id)->toBe($actor->id);
+    expect($entry->subject_id)->toBe($subject->id);
+    expect($entry->subject_type)->toBe(User::class);
+    expect($entry->properties['attributes']['reason'])->toBe('because');
+});
+
+test('given a privileged action, when recorded, then it is also written to the application log', function () {
+    $logs = captureLogs();
+    $actor = User::factory()->create();
+
+    $this->actingAs($actor);
+
+    PrivilegedAction::record('test.action', null, ['reason' => 'because']);
+
+    $record = findLog($logs, 'privileged action: test.action');
+
+    expect($record)->not->toBeNull();
+    expect($record['level'])->toBe('INFO');
+    expect($record['context']['actor_cid'])->toBe($actor->id);
+    expect($record['context']['reason'])->toBe('because');
+});
+
+test('given a privileged action from the console, when recorded, then it is tagged as a console action with no actor', function () {
+    PrivilegedAction::record('test.action');
+
+    $entry = Activity::where('event', 'test.action')->first();
+
+    expect($entry->causer_id)->toBeNull();
+    expect($entry->properties['context']['source'])->toBe('console');
+});
+
+test('given a privileged action over http, when recorded, then the request origin is captured for forensics', function () {
+    $actor = User::factory()->create();
+    // The contributor routes sit behind role:admin inside the admin prefix,
+    // which additionally requires the 'view dashboard' permission.
+    $actor->assignRole('admin');
+    $actor->givePermissionTo('view dashboard');
+
+    $this->actingAs($actor)->post(route('admin.contributors.store'), [
+        'github_username' => 'octocat',
+        'section' => 'contributor',
+    ]);
+
+    $entry = Activity::where('event', PrivilegedAction::CONTRIBUTOR_ADDED)->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->properties['context']['source'])->toBe('web');
+    expect($entry->properties['context']['route'])->toBe('admin.contributors.store');
+    expect($entry->properties['context']['method'])->toBe('POST');
+    expect($entry->properties['context'])->toHaveKey('ip');
+});
+
+test('given the activity log write fails, when an action is recorded, then the action still succeeds and the gap is logged', function () {
+    $logs = captureLogs();
+
+    // Simulate the audit table being unavailable.
+    app()->bind(ActivityLogger::class, function () {
+        throw new RuntimeException('activity_log is unavailable');
+    });
+
+    PrivilegedAction::record('test.action', null, ['reason' => 'because']);
+
+    $critical = findLog($logs, 'Failed to write privileged action to the audit log');
+
+    expect($critical)->not->toBeNull();
+    expect($critical['level'])->toBe('CRITICAL');
+    // The file-log trail must survive even when the database trail does not.
+    expect(findLog($logs, 'privileged action: test.action'))->not->toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// Visitor acceptances — named explicitly in the issue.
+// ---------------------------------------------------------------------------
+
+function pendingVisitRequest(): VisitorRequest
+{
+    return VisitorRequest::create([
+        'user_id' => User::factory()->create(['rostered' => false])->id,
+        'user_note' => 'I would like to visit.',
+        'status' => VisitRequestStatus::PENDING,
+    ]);
+}
+
+function visitingStaff(): User
+{
+    $staff = User::factory()->create();
+    $staff->givePermissionTo('view dashboard', 'manage visiting controllers');
+
+    return $staff;
+}
+
+test('given a visitor request, when it is approved, then the approval is audited with who approved it', function () {
+    $staff = visitingStaff();
+    $visitRequest = pendingVisitRequest();
+
+    $this->actingAs($staff)
+        ->put(route('visit.approve', $visitRequest->id), [
+            'operatingInitials' => 'AB',
+            'adminNotes' => 'Looks good',
+        ]);
+
+    $entry = Activity::where('event', PrivilegedAction::VISITOR_REQUEST_APPROVED)->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->causer_id)->toBe($staff->id);
+    expect($entry->properties['attributes']['cid'])->toBe($visitRequest->user_id);
+    expect($entry->properties['attributes']['operating_initials'])->toBe('AB');
+    expect($entry->properties['attributes']['admin_notes'])->toBe('Looks good');
+});
+
+test('given a visitor request, when it is denied, then the reason is captured in the audit trail', function () {
+    $staff = visitingStaff();
+    $visitRequest = pendingVisitRequest();
+
+    $this->actingAs($staff)
+        ->put(route('visit.deny', $visitRequest->id), [
+            'reason' => 'Insufficient hours',
+            'adminNotes' => 'Revisit in 3 months',
+        ]);
+
+    $entry = Activity::where('event', PrivilegedAction::VISITOR_REQUEST_DENIED)->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->causer_id)->toBe($staff->id);
+    expect($entry->properties['attributes']['reason'])->toBe('Insufficient hours');
+});
+
+test('given an approval that is rejected for duplicate operating initials, when it fails, then nothing is audited', function () {
+    $staff = visitingStaff();
+    User::factory()->create(['operating_initials' => 'AB']);
+    $visitRequest = pendingVisitRequest();
+
+    $this->actingAs($staff)
+        ->put(route('visit.approve', $visitRequest->id), ['operatingInitials' => 'AB']);
+
+    expect(Activity::where('event', PrivilegedAction::VISITOR_REQUEST_APPROVED)->count())->toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// Deletions
+// ---------------------------------------------------------------------------
+
+test('given a contributor is removed, when the record is deleted, then the audit entry still describes what was deleted', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+    $admin->givePermissionTo('view dashboard');
+
+    $contributor = ManualContributor::create([
+        'github_username' => 'octocat',
+        'section' => 'contributor',
+        'note' => 'Helped with the roster page',
+    ]);
+
+    $this->actingAs($admin)->delete(route('admin.contributors.destroy', $contributor->id));
+
+    $entry = Activity::where('event', PrivilegedAction::CONTRIBUTOR_REMOVED)->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->causer_id)->toBe($admin->id);
+    // Snapshotted before the delete, so the trail is not just a bare ID.
+    expect($entry->properties['attributes']['github_username'])->toBe('octocat');
+    expect($entry->properties['attributes']['note'])->toBe('Helped with the roster page');
+    expect(ManualContributor::count())->toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// The existing admin viewer has to be able to render these new events.
+// ---------------------------------------------------------------------------
+
+test('given a privileged action is recorded, when staff open the audit log, then the action and its detail are shown', function () {
+    $staff = visitingStaff();
+    $visitRequest = pendingVisitRequest();
+
+    $this->actingAs($staff)
+        ->put(route('visit.approve', $visitRequest->id), ['operatingInitials' => 'CD']);
+
+    $staff->givePermissionTo('view audit logs');
+
+    $response = $this->actingAs($staff->fresh())->get(route('logs.index'));
+
+    $response->assertStatus(200);
+    $response->assertSee(PrivilegedAction::VISITOR_REQUEST_APPROVED);
+    $response->assertSee('Operating Initials');
+    $response->assertSee('CD');
+});
+
+test('given a privileged action is recorded, when staff export the audit log, then it appears in the csv', function () {
+    $staff = visitingStaff();
+    $visitRequest = pendingVisitRequest();
+
+    $this->actingAs($staff)
+        ->put(route('visit.approve', $visitRequest->id), ['operatingInitials' => 'CD']);
+
+    $staff->givePermissionTo('view audit logs');
+
+    $response = $this->actingAs($staff->fresh())->get(route('logs.export'));
+
+    $response->assertStatus(200);
+
+    $csv = $response->streamedContent();
+
+    expect($csv)->toContain(PrivilegedAction::VISITOR_REQUEST_APPROVED);
+    expect($csv)->toContain('Operating Initials: CD');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use Tests\TestCase;
 
 /*
@@ -61,4 +65,44 @@ expect()->extend('toRunInLessThan', function (int $milliseconds) {
 function something()
 {
     // ..
+}
+
+/**
+ * Swap the logger for one that records everything in memory, so tests can
+ * assert on what was actually logged — level, message and context.
+ *
+ * A Monolog TestHandler is used rather than a facade spy because the code under
+ * test reaches the logger by several routes (Log::info, Log::log($level, ...)),
+ * and what matters is the record that comes out the far end, not which method
+ * was called to get there.
+ */
+function captureLogs(): TestHandler
+{
+    $handler = new TestHandler(Level::Debug);
+
+    Log::swap(
+        new Illuminate\Log\Logger(new Logger('testing', [$handler]))
+    );
+
+    return $handler;
+}
+
+/**
+ * Find the first captured record whose message contains $needle.
+ *
+ * @return array<string, mixed>|null
+ */
+function findLog(TestHandler $handler, string $needle): ?array
+{
+    foreach ($handler->getRecords() as $record) {
+        if (str_contains($record['message'], $needle)) {
+            return [
+                'level' => $record['level_name'],
+                'message' => $record['message'],
+                'context' => $record['context'],
+            ];
+        }
+    }
+
+    return null;
 }


### PR DESCRIPTION
Closes #174

Adds the three logging capabilities the issue asked for, plus docs and tests.

## Cronjobs now log on success, not just failure

A job that had silently stopped running was indistinguishable from one that ran
and found nothing to do. `App\Jobs\Concerns\LogsJobRun` gives every job a
correlated run log — a debug line on start, a summary with duration and per-run
counters on completion, and error lines for aborts and exceptions. Every line of
a run carries the same `run_id`, so overlapping runs can be told apart:

```
SyncStatsimSessions completed {"job":"App\\Jobs\\SyncStatsimSessions",
  "run_id":"0193f0c2-…","duration_ms":812.4,"sessions_received":143,
  "sessions_stored":97,"skipped_unrostered":31,"skipped_foreign_prefix":15,
  "controllers_recomputed":22,"year":2026,"month":8}
```

Instrumented: `SyncStatsimSessions` (the one named in the issue), `SyncRoster`,
`SyncTrainingTickets`, `UpdateOnlineControllers`. The every-minute
`UpdateOnlineControllers` reports its summary at `debug` — at `info` it would add
~1,400 lines a day saying nothing happened — while its failures stay at `error`.

## Privileged ("sudo") actions are audited

`App\Support\PrivilegedAction::record()` writes each staff action to **both**
trails in one call: the `activity_log` table, so it appears in the existing admin
audit viewer, and the application log, so it survives loss of the database.

Covers visitor approvals/denials, solo cert issue/revoke, training assignment
update/claim/drop/forfeit, contributor add/remove, manual statistics syncs, and
roster departures (recorded with no causer, since VATUSA rather than a staff
member dropped them).

Each entry stores the action detail under `properties['attributes']` (rendered by
the viewer and CSV export) and request forensics — `source`, `ip`, `route`,
`method` — under `properties['context']`.

**One judgement call worth reviewing:** the `activity_log` write is best-effort.
If it throws, the failure is logged at `critical` and the staff action still
succeeds, rather than an audit-log outage turning every approval into a 500. The
application-log copy still records the action. Happy to make it strict instead if
you'd rather the audit guarantee win over availability.

## Debug logging

Phase-level debug output through the syncs — roster fetch, membership diff with
the actual joined/departed CIDs, per-staff-position role assignment, Statsim
prefix filtering, per-ticket VATUSA record IDs.

Rather than only offering `LOG_LEVEL=debug`, there's a dedicated `debug` channel
so detail can be captured without turning the main log down:

```dotenv
LOG_STACK=daily,debug
LOG_DEBUG_DAYS=3
```

That writes debug output to `storage/logs/debug.log` on a short rotation while the
main channel stays at `info`.

## Two latent bugs fixed along the way

- `UpdateOnlineControllers` called `truncate()` on `online_controllers` *before*
  checking whether the VATSIM fetch succeeded, so any upstream blip emptied the
  table — and `json_decode` on a failed response then crashed the loop. It now
  checks the response first. Regression test included.
- Web vs console origin is detected by route presence rather than
  `runningInConsole()`, which is true under the test runner even for HTTP requests.

## Docs

New `docs/systems/logging.md`, plus updates to `architecture.md` (the scheduled
work table was missing the daily Statsim job), `deployment.md`, and
`audit-logging.md` — which was already stale, listing four audited models when
`Publication` and `PublicationCategory` had since been added.

## Tests

25 new tests across `tests/Feature/JobRunLoggingTest.php` and
`tests/Feature/PrivilegedActionLoggingTest.php`; 64 pass overall, Pint clean.

The `captureLogs()` / `findLog()` helpers in `tests/Pest.php` assert on real
Monolog records — level, message and context — via a `TestHandler` rather than
facade spies, so they verify what actually comes out the far end instead of which
method was called.

## Known unrelated issue

`VatusaFacilityInfoDTO` only initialises its typed `$roles` property inside its
loop, so an empty roles array leaves it uninitialised and `Staff::fromFacilityInfoDTO`
fatals. I worked around it in test fixtures rather than fixing it here since it's
out of scope — worth a separate ticket.
