### PR TITLE
Improve logging coverage for reliability monitoring

### DIFF
--- a/app/Http/Controllers/Admin/ManualContributorController.php
+++ b/app/Http/Controllers/Admin/ManualContributorController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\ManualContributor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 class ManualContributorController extends Controller
 {
@@ -25,8 +27,16 @@ class ManualContributorController extends Controller
             'note' => 'nullable|string|max:100',
         ]);
 
-        ManualContributor::create($validated);
+        $contributor = ManualContributor::create($validated);
         Cache::forget('github_contributors');
+
+        Log::info('Contributor added', [
+            'contributor_id' => $contributor->id,
+            'github_username' => $validated['github_username'] ?? null,
+            'display_name' => $validated['display_name'] ?? null,
+            'section' => $validated['section'],
+            'added_by' => Auth::user()->id,
+        ]);
 
         $label = $validated['github_username'] ? "@{$validated['github_username']}" : ($validated['display_name'] ?? 'Contributor');
 
@@ -35,6 +45,14 @@ class ManualContributorController extends Controller
 
     public function destroy(ManualContributor $contributor)
     {
+        Log::info('Contributor removed', [
+            'contributor_id' => $contributor->id,
+            'github_username' => $contributor->github_username,
+            'display_name' => $contributor->display_name,
+            'section' => $contributor->section,
+            'removed_by' => Auth::user()->id,
+        ]);
+
         $contributor->delete();
         Cache::forget('github_contributors');
 

--- a/app/Http/Controllers/Training/SoloCertController.php
+++ b/app/Http/Controllers/Training/SoloCertController.php
@@ -109,6 +109,13 @@ class SoloCertController extends Controller
 
         Mail::to($soloCert->user)->bcc([$soloCert->issuedBy, config('app.vatusa_facility').'-ta@vatusa.net'])->queue(new SoloCertRevoked($soloCert));
 
+        Log::info('Solo cert revoked', [
+            'solo_cert_id' => $soloCert->id,
+            'user_id' => $soloCert->user_id,
+            'position' => $soloCert->position,
+            'revoked_by' => Auth::user()->id,
+        ]);
+
         return redirect(route('solo-certs.index'))->with('success', 'Solo certification revoked successfully.');
     }
 }

--- a/app/Http/Controllers/Training/TrainingAssignmentController.php
+++ b/app/Http/Controllers/Training/TrainingAssignmentController.php
@@ -148,6 +148,12 @@ class TrainingAssignmentController extends Controller
 
         Mail::to($assignment->student->email)->bcc($assignment->instructor ?? null)->queue(new TrainingAssignmentUpdated($assignment));
 
+        Log::info('Training assignment claimed', [
+            'assignment_id' => $assignment->id,
+            'student_id' => $assignment->user_id,
+            'claimed_by' => Auth::user()->id,
+        ]);
+
         return redirect()->back()->with('success', 'Training assignment claimed successfully');
     }
 
@@ -164,13 +170,27 @@ class TrainingAssignmentController extends Controller
             return redirect()->back()->with('error', 'Cannot update inactive training assignment.');
         }
 
+        $previousInstructorId = $assignment->instructor_id;
+        $dropped = false;
+
         if ($assignment->instructor_id == $user->id || $user->hasPermissionTo('manage students')) {
             $assignment->update([
                 'instructor_id' => null,
             ]);
+            $dropped = true;
         }
 
         Mail::to($assignment->student->email)->queue(new TrainingAssignmentUpdated($assignment));
+
+        Log::info('Training assignment dropped', [
+            'assignment_id' => $assignment->id,
+            'student_id' => $assignment->user_id,
+            'previous_instructor_id' => $previousInstructorId,
+            // The route reports success either way, so record whether the
+            // instructor was actually cleared.
+            'instructor_cleared' => $dropped,
+            'dropped_by' => $user->id,
+        ]);
 
         return redirect()->back()->with('success', 'Training assignment dropped successfully');
     }
@@ -192,6 +212,13 @@ class TrainingAssignmentController extends Controller
             $assignment->active = false;
             $assignment->status = TrainingStatus::FORFEIT;
             $assignment->save();
+
+            Log::info('Training assignment forfeited', [
+                'assignment_id' => $assignment->id,
+                'student_id' => $assignment->user_id,
+                'instructor_id' => $assignment->instructor_id,
+                'forfeited_by' => $user->id,
+            ]);
 
             return redirect()->back()->with('success', 'Training assignment deactivated successfully');
         } else {

--- a/app/Http/Controllers/VisitFacilityController.php
+++ b/app/Http/Controllers/VisitFacilityController.php
@@ -77,7 +77,10 @@ class VisitFacilityController extends Controller
         ]);
 
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestReceived($visitRequest));
-        Log::info('New visit request submitted for user '.$visitRequest->user_id.' by '.Auth::user()->id);
+        Log::info('Visit request submitted', [
+            'visit_request_id' => $visitRequest->id,
+            'user_id' => $visitRequest->user_id,
+        ]);
 
         return redirect()->route('visit.index')->with('success', 'Visit request submitted successfully.');
     }
@@ -100,7 +103,13 @@ class VisitFacilityController extends Controller
         $visitRequest->status = VisitRequestStatus::DENIED;
         $visitRequest->save();
 
-        Log::info('Visit request for user '.$visitRequest->user_id.' denied. Reason: '.$validated['reason'].' Admin Notes: '.($validated['adminNotes'] ?? 'N/A').' by '.Auth::user()->id);
+        Log::info('Visit request denied', [
+            'visit_request_id' => $visitRequest->id,
+            'user_id' => $visitRequest->user_id,
+            'reason' => $validated['reason'],
+            'admin_notes' => $validated['adminNotes'] ?? null,
+            'denied_by' => Auth::user()->id,
+        ]);
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestRejected($visitRequest));
 
         return redirect()->back()->with('success', 'Visit request denied.');
@@ -135,7 +144,13 @@ class VisitFacilityController extends Controller
 
         Mail::to($visitRequest->user->email)->bcc(['atm@zjxartcc.org', 'datm@zjxartcc.org'])->queue(new VisitorRequestAccepted($visitRequest));
         AddUserToVisitingRoster::dispatch($visitRequest->user->id);
-        Log::info('Visit request for user '.$visitRequest->user_id.' approved. Operating Initials: '.$validated['operatingInitials'].' Admin Notes: '.($validated['adminNotes'] ?? 'N/A').' by '.Auth::user()->id);
+        Log::info('Visit request approved', [
+            'visit_request_id' => $visitRequest->id,
+            'user_id' => $visitRequest->user_id,
+            'operating_initials' => strtoupper($validated['operatingInitials']),
+            'admin_notes' => $validated['adminNotes'] ?? null,
+            'approved_by' => Auth::user()->id,
+        ]);
 
         return redirect()->back()->with('success', 'Visit request approved.');
     }

--- a/app/Jobs/SyncRoster.php
+++ b/app/Jobs/SyncRoster.php
@@ -26,6 +26,8 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     {
         $ROSTER_API_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility').'/roster/both';
 
+        Log::debug('Fetching roster from VATUSA', ['endpoint' => $ROSTER_API_ENDPOINT]);
+
         $rosterData = Http::get($ROSTER_API_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
@@ -35,12 +37,37 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
         }
 
         $roster = $rosterData->json();
+
+        // Snapshot membership so joiners and leavers can be reported.
+        $before = User::where('rostered', true)->pluck('id')->all();
+
         User::where(['rostered' => true])->update(['rostered' => false]);
 
         for ($i = 0; $i < count($roster['data']); $i++) {
             $vatusaUser = new VatusaRosterUser($roster['data'][$i]);
 
             User::updateFromVatusa($vatusaUser);
+        }
+
+        $after = User::where('rostered', true)->pluck('id')->all();
+        $joined = array_values(array_diff($after, $before));
+        $departed = array_values(array_diff($before, $after));
+
+        Log::debug('Roster membership diff', [
+            'roster_size' => count($roster['data']),
+            'joined_cids' => $joined,
+            'departed_cids' => $departed,
+        ]);
+
+        foreach ($departed as $cid) {
+            Log::info('Controller removed from roster', [
+                'cid' => $cid,
+                'reason' => 'no longer present on the VATUSA roster',
+            ]);
+        }
+
+        foreach ($joined as $cid) {
+            Log::info('Controller added to roster', ['cid' => $cid]);
         }
 
         // Clear hanging OIs
@@ -80,6 +107,18 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
         foreach ($staffMembers as $staff) {
             $user = $staff->user;
 
+            if (! $user) {
+                Log::warning('Staff position references a user not on the roster', [
+                    'cid' => $staff->user_id,
+                    'title' => $staff->title_short,
+                ]);
+            }
+
+            Log::debug('Assigning staff roles', [
+                'cid' => $staff->user_id,
+                'title' => $staff->title_short,
+            ]);
+
             switch ($staff->title_short) {
                 case 'ATM':
                 case 'DATM':
@@ -111,6 +150,9 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     private function updateStaffMembers()
     {
         $FACILITY_INFO_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility');
+
+        Log::debug('Fetching facility info from VATUSA', ['endpoint' => $FACILITY_INFO_ENDPOINT]);
+
         $facilityInfo = Http::get($FACILITY_INFO_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
@@ -155,7 +197,10 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
 
             $this->syncRosteredRole();
 
-            Log::info('Roster sync completed successfully.');
+            Log::info('Roster sync complete', [
+                'rostered_controllers' => User::where('rostered', true)->count(),
+                'staff_positions' => Staff::count(),
+            ]);
         } catch (\Exception $e) {
             // Log error
             Log::error('Error syncing roster: '.$e->getMessage().'\n'.$e->getTraceAsString(), [

--- a/app/Jobs/SyncStatsimSessions.php
+++ b/app/Jobs/SyncStatsimSessions.php
@@ -54,6 +54,14 @@ class SyncStatsimSessions implements ShouldQueue
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         $rosteredCids = User::where('rostered', true)->pluck('id')->flip();
         $touchedUserIds = [];
+        $stored = 0;
+        $skipped = 0;
+
+        Log::debug('Statsim sync fetched sessions', [
+            'count' => count($sessions),
+            'prefixes' => $prefixes,
+            'rostered_controllers' => $rosteredCids->count(),
+        ]);
 
         foreach ($sessions as $session) {
             $callsign = $session['callsign'] ?? null;
@@ -63,20 +71,28 @@ class SyncStatsimSessions implements ShouldQueue
             $loggedOff = $session['loggedOff'] ?? null;
 
             if (! $callsign || ! $vatsimId || ! $sessionId || ! $loggedOn || ! $loggedOff) {
+                $skipped++;
+
                 continue;
             }
 
             if (! Str::startsWith($callsign, $prefixes)) {
+                $skipped++;
+
                 continue;
             }
 
             $userId = (int) $vatsimId;
             if (! $rosteredCids->has($userId)) {
+                $skipped++;
+
                 continue;
             }
 
             $facilityLevel = $this->facilityLevel(Str::upper(Str::substr($callsign, -3)));
             if ($facilityLevel < 2) {
+                $skipped++;
+
                 continue;
             }
 
@@ -91,12 +107,22 @@ class SyncStatsimSessions implements ShouldQueue
                 ]
             );
 
+            $stored++;
             $touchedUserIds[$userId] = true;
         }
 
         foreach (array_keys($touchedUserIds) as $userId) {
             $this->recomputeMonthlyStats($userId, $this->year, $this->month);
         }
+
+        Log::info('Statsim sync complete', [
+            'year' => $this->year,
+            'month' => $this->month,
+            'sessions_received' => count($sessions),
+            'sessions_stored' => $stored,
+            'sessions_skipped' => $skipped,
+            'controllers_updated' => count($touchedUserIds),
+        ]);
     }
 
     private function facilityLevel(string $suffix): int

--- a/app/Jobs/SyncTrainingTickets.php
+++ b/app/Jobs/SyncTrainingTickets.php
@@ -14,6 +14,8 @@ class SyncTrainingTickets implements ShouldQueue
 {
     use Queueable;
 
+    private int $synced = 0;
+
     /**
      * Create a new job instance.
      */
@@ -28,11 +30,17 @@ class SyncTrainingTickets implements ShouldQueue
     public function handle(): void
     {
         // https://api.vatusa.net/v2/training/record/{recordID}
-        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false]);
+        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false])->get();
 
-        foreach ($unsyncedTickets->get() as $ticket) {
+        foreach ($unsyncedTickets as $ticket) {
             $this->createVatusaTrainingTicket($ticket);
         }
+
+        Log::info('Training ticket sync complete', [
+            'tickets_pending' => $unsyncedTickets->count(),
+            'tickets_synced' => $this->synced,
+            'tickets_failed' => $unsyncedTickets->count() - $this->synced,
+        ]);
     }
 
     private function createVatusaTrainingTicket(mixed $ticket)
@@ -87,5 +95,13 @@ class SyncTrainingTickets implements ShouldQueue
         $ticket->vatusa_synced = true;
         $ticket->vatusa_id = $vatusaId ? (string) $vatusaId : substr(preg_replace('/[^a-z0-9]/i', '', sha1($request->body() ?? (string) microtime(true))), 0, 12);
         $ticket->save();
+
+        $this->synced++;
+
+        Log::debug('Training ticket synced to VATUSA', [
+            'ticket_id' => $ticket->id,
+            'user_id' => $ticket->user_id,
+            'vatusa_id' => $ticket->vatusa_id,
+        ]);
     }
 }

--- a/app/Jobs/UpdateOnlineControllers.php
+++ b/app/Jobs/UpdateOnlineControllers.php
@@ -8,6 +8,7 @@ use App\Models\StatisticsPrefixes;
 use Http;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Str;
 
 class UpdateOnlineControllers implements ShouldQueue
@@ -28,15 +29,44 @@ class UpdateOnlineControllers implements ShouldQueue
 
         $onlineData = Http::get($API_ENDPOINT);
 
-        $controllers = json_decode($onlineData, true);
+        // Checked before truncating: previously a failed request still emptied
+        // the table, so any VATSIM blip showed the facility as fully offline.
+        if ($onlineData->failed()) {
+            Log::error('Online controller sync failed', [
+                'status' => $onlineData->status(),
+                'endpoint' => $API_ENDPOINT,
+            ]);
+
+            return;
+        }
+
+        $controllers = $onlineData->json();
+
+        if (! is_array($controllers)) {
+            Log::error('Online controller sync got a non-array payload', ['endpoint' => $API_ENDPOINT]);
+
+            return;
+        }
+
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         OnlineController::truncate();
+
+        $facilityCount = 0;
 
         foreach ($controllers as $controller) {
             $onlineController = new OnlineControllerDTO($controller);
             if (Str::startsWith($onlineController->callsign, $prefixes)) {
                 OnlineController::fromDTO($onlineController);
+                $facilityCount++;
+                Log::debug('Facility controller online', ['callsign' => $onlineController->callsign]);
             }
         }
+
+        // Debug rather than info: this job runs every minute, so an info line
+        // per run would add ~1,400 lines a day saying nothing changed.
+        Log::debug('Online controller sync complete', [
+            'network_controllers' => count($controllers),
+            'facility_controllers' => $facilityCount,
+        ]);
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,15 +130,75 @@ The scheduler is defined in `routes/console.php` (the console entry registered b
 | --- | --- | --- |
 | `Schedule::job(new SyncRoster())` | `app/Jobs/SyncRoster.php` | Every two hours |
 | `Schedule::job(new UpdateOnlineControllers())` | `app/Jobs/UpdateOnlineControllers.php` | Every minute |
+| `Schedule::call(...)` | `app/Jobs/SyncStatsimSessions.php` | Daily at 04:00, for the current and previous month |
 
 `SyncRoster` pulls the controller roster from VATUSA; `UpdateOnlineControllers` refreshes
-who is currently online. Both are covered in [VATSIM integration](vatsim-integration.md)
+who is currently online; `SyncStatsimSessions` backfills controller session statistics
+(the previous month is re-synced because Statsim can backfill after the month rolls over).
+The first two are covered in [VATSIM integration](vatsim-integration.md)
 and [roster and membership](systems/roster-and-membership.md). In local/development you can
 trigger these manually via the dev-only `/sync` route.
 
 Because scheduled work is dispatched as queued jobs, a queue worker and the scheduler both
 need to run. `composer run dev` starts `php artisan serve`, `php artisan queue:listen`,
 `php artisan pail`, and `npm run dev` together for local development.
+
+## Logging
+
+Standard Laravel logging (`Illuminate\Support\Facades\Log`) throughout — channels are
+configured in `config/logging.php` and selected with `LOG_STACK`. Levels follow their
+usual RFC 5424 meanings.
+
+Pass context as an array rather than interpolating into the message, so lines stay
+greppable and structured:
+
+```php
+Log::info('Visit request approved', [
+    'user_id' => $visitRequest->user_id,
+    'approved_by' => Auth::user()->id,
+]);
+```
+
+### What gets logged
+
+**Sync jobs log on success, not just on failure** — otherwise a job that has silently
+stopped running looks identical to one that ran and found nothing to do. Each emits a
+completion line with counts:
+
+| Job | Line | Level |
+| --- | --- | --- |
+| `SyncRoster` | `Roster sync complete` | `info` |
+| `SyncStatsimSessions` | `Statsim sync complete` | `info` |
+| `SyncTrainingTickets` | `Training ticket sync complete` | `info` |
+| `UpdateOnlineControllers` | `Online controller sync complete` | `debug` |
+
+`UpdateOnlineControllers` reports at `debug` because it runs every minute; at `info` it
+would add roughly 1,400 lines a day. Its failures are still logged at `error`.
+
+**Privileged actions are logged at `info`** with the acting user's CID — visit request
+submitted/approved/denied, solo cert issued/revoked, training assignment
+updated/claimed/dropped/forfeited, training ticket created, statistics prefix
+added/deleted, contributor added/removed, and controllers joining or leaving the roster.
+
+This is separate from the database audit trail, which records model lifecycles and is
+viewable in the admin area — see [audit logging](systems/audit-logging.md).
+
+### Debug mode
+
+Debug output is off by default. To investigate a sync, set:
+
+```dotenv
+LOG_LEVEL=debug
+```
+
+`SyncRoster` is the most heavily instrumented, since it is the sync most likely to need
+investigating: the endpoints being called, the full membership diff (`joined_cids` /
+`departed_cids`), and per-position staff role assignment. `SyncStatsimSessions` logs the
+prefixes and rostered-controller count it filters against; `UpdateOnlineControllers` logs
+each facility controller found online; `SyncTrainingTickets` logs each ticket synced.
+
+Set `LOG_LEVEL` back to `info` afterwards — debug output is high volume and, if the
+Discord channel is in `LOG_STACK`, it ships there too.
 
 ## Infrastructure drivers
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,11 @@ files (`config/app.php`, `config/logging.php`, `config/mail.php`) but are not pr
 ### Logging
 
 - `LOG_CHANNEL`, `LOG_STACK`, `LOG_DEPRECATIONS_CHANNEL`, `LOG_LEVEL` — log routing and
-  verbosity.
+  verbosity. Run production at `LOG_LEVEL=info`; sync jobs emit their completion
+  summaries at that level. Drop to `debug` temporarily to investigate a sync — see
+  [logging](architecture.md#logging).
+- Note `LOG_STACK` is comma-separated and defaults to `single`. The `discord` channel
+  only receives anything if it is listed there (e.g. `LOG_STACK=daily,discord`).
 
 ### Database
 

--- a/tests/Feature/LoggingTest.php
+++ b/tests/Feature/LoggingTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Jobs\SyncRoster;
+use App\Jobs\SyncStatsimSessions;
+use App\Jobs\UpdateOnlineControllers;
+use App\Models\OnlineController;
+use App\Models\StatisticsPrefixes;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+beforeEach(function () {
+    // Creating a User assigns the default 'core' role.
+    $this->seed(PermissionSeeder::class);
+});
+
+function statsimSession(array $overrides = []): array
+{
+    return array_merge([
+        'id' => 1,
+        'callsign' => 'JAX_CTR',
+        'vatsimid' => '100',
+        'loggedOn' => '2026-01-05 12:00:00',
+        'loggedOff' => '2026-01-05 14:00:00',
+    ], $overrides);
+}
+
+function fakeVatusaRoster(array $cids): void
+{
+    $now = (new DateTime)->format('Y-m-d H:i:s');
+    $staffCid = $cids[0] ?? 100;
+
+    $entry = fn ($cid) => [
+        'cid' => $cid, 'fname' => 'Test', 'lname' => 'Controller', 'rating' => 6,
+        'email' => "test{$cid}@example.com", 'facility' => 'ZJX',
+        'created_at' => $now, 'updated_at' => $now, 'facility_join' => $now,
+        'flag_needbasic' => false, 'flag_xferOverride' => false,
+        'flag_homecontroller' => true, 'lastactivity' => $now,
+        'flag_broadcastOptedIn' => false, 'flag_preventStaffAssign' => false,
+        'discord_id' => null, 'flag_nameprivacy' => false,
+        'last_competency_date' => $now, 'promotion_eligible' => false,
+        'transfer_eligible' => false, 'roles' => [], 'isMentor' => false,
+        'isSupIns' => false, 'last_promotion' => $now,
+    ];
+
+    Http::fake([
+        '*/roster/both*' => Http::response(['data' => array_map($entry, $cids)]),
+        '*/v2/facility/*' => Http::response(['data' => ['facility' => [
+            'info' => array_fill_keys(['atm', 'datm', 'ta', 'wm', 'ec', 'fe'], $staffCid),
+            // VatusaFacilityInfoDTO only initialises its typed $roles property
+            // inside the loop, so an empty list leaves it uninitialised.
+            'roles' => [['cid' => $staffCid, 'role' => 'ATM', 'created_at' => $now]],
+        ]]]),
+    ]);
+}
+
+test('statsim sync logs a summary on success, not only on error', function () {
+    Log::spy();
+
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+
+    Http::fake(['api.statsim.net/*' => Http::response([statsimSession()])]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    Log::shouldHaveReceived('info')->withArgs(
+        fn ($message, $context) => $message === 'Statsim sync complete'
+            && $context['sessions_received'] === 1
+            && $context['sessions_stored'] === 1
+            && $context['controllers_updated'] === 1
+    )->once();
+});
+
+test('statsim sync reports skipped sessions in its summary', function () {
+    Log::spy();
+
+    StatisticsPrefixes::create(['name' => 'JAX']);
+    User::factory()->create(['id' => 100, 'rostered' => true]);
+
+    Http::fake(['api.statsim.net/*' => Http::response([
+        statsimSession(['id' => 1]),
+        statsimSession(['id' => 2, 'vatsimid' => '200']),   // not rostered
+        statsimSession(['id' => 3, 'callsign' => 'ATL_CTR']), // other facility
+    ])]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    Log::shouldHaveReceived('info')->withArgs(
+        fn ($message, $context) => $message === 'Statsim sync complete'
+            && $context['sessions_stored'] === 1
+            && $context['sessions_skipped'] === 2
+    )->once();
+});
+
+test('roster sync logs each controller removed from the roster', function () {
+    Log::spy();
+
+    User::factory()->create(['id' => 200, 'rostered' => true]);
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    Log::shouldHaveReceived('info')->withArgs(
+        fn ($message, $context) => $message === 'Controller removed from roster'
+            && $context['cid'] === 200
+    )->once();
+});
+
+test('roster sync emits debug detail for each phase', function () {
+    Log::spy();
+
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    Log::shouldHaveReceived('debug')->withArgs(
+        fn ($message) => $message === 'Fetching roster from VATUSA'
+    )->once();
+
+    Log::shouldHaveReceived('debug')->withArgs(
+        fn ($message) => $message === 'Roster membership diff'
+    )->once();
+});
+
+test('online controller sync keeps existing rows when the vatsim api fails', function () {
+    Log::spy();
+
+    OnlineController::create(['callsign' => 'JAX_CTR', 'user_id' => 100, 'start' => now()]);
+
+    Http::fake(['*' => Http::response('gateway timeout', 504)]);
+
+    (new UpdateOnlineControllers)->handle();
+
+    Log::shouldHaveReceived('error')->withArgs(
+        fn ($message, $context) => $message === 'Online controller sync failed'
+            && $context['status'] === 504
+    )->once();
+
+    // Previously the table was truncated before the response was checked.
+    expect(OnlineController::count())->toBe(1);
+});


### PR DESCRIPTION
Closes #174

Uses standard Laravel logging throughout — no new classes, traits or abstractions to
learn. 192 lines of production code, plus tests and docs.

## Cronjobs now log on success, not only on failure

A job that had silently stopped running was indistinguishable from one that ran and
found nothing to do. Each sync now emits a completion line with counts:

| Job | Line | Level |
| --- | --- | --- |
| `SyncRoster` | `Roster sync complete` | `info` |
| `SyncStatsimSessions` | `Statsim sync complete` | `info` |
| `SyncTrainingTickets` | `Training ticket sync complete` | `info` |
| `UpdateOnlineControllers` | `Online controller sync complete` | `debug` |

`SyncStatsimSessions` — the one named in the issue — previously logged only on error.
It now reports `sessions_received`, `sessions_stored`, `sessions_skipped` and
`controllers_updated`, so a sync that runs but quietly stops storing anything is
visible. `SyncRoster`'s existing line said only "completed successfully"; it now
carries counts.

`UpdateOnlineControllers` reports at `debug` because it runs every minute — at `info`
it would add roughly 1,400 lines a day. Its failures are still logged at `error`.

## Privileged actions

These had no logging at all and now do: solo cert revoked, training assignment
claimed / dropped / forfeited, contributor added / removed, and controllers joining
or leaving the roster (the "user removals" from the issue).

The three visit request lines already logged, but via string concatenation. They have
been rebuilt with context arrays to match the style already used in
`SoloCertController` and `StatisticsPrefixesController`:

```php
Log::info('Visit request approved', [
    'user_id' => $visitRequest->user_id,
    'operating_initials' => 'AB',
    'approved_by' => Auth::user()->id,
]);
```

This is the application log only. The database audit trail is untouched.

## Debug logging

Did not exist anywhere before — there were zero `Log::debug` calls in the codebase.
Enable with `LOG_LEVEL=debug`.

`SyncRoster` is the most instrumented, since it is the sync most likely to need
investigating: the endpoints being called, the full membership diff
(`joined_cids` / `departed_cids`), and per-position staff role assignment.
`SyncStatsimSessions` logs the prefixes and rostered-controller count it filters
against; `UpdateOnlineControllers` logs each facility controller online;
`SyncTrainingTickets` logs each ticket synced.

## Bug fixed along the way

`UpdateOnlineControllers` called `truncate()` on `online_controllers` **before**
checking whether the VATSIM request succeeded — so any upstream blip emptied the table
and showed the facility as fully offline, and the subsequent `json_decode` on a failed
response crashed the loop. It now checks the response first. There is a test pinning
this.

## Docs

New `## Logging` section in `docs/architecture.md` covering the conventions, what gets
logged, and how to turn on debug mode. `docs/deployment.md` gains a note that the
`discord` channel only receives output if it is listed in `LOG_STACK` — worth checking
on the server, since `.env.example` ships `LOG_STACK=single`.

Also added the daily Statsim job to the scheduled-work table, which was missing it.

## Tests

5 new tests using stock `Log::spy()` — no test helpers added. 44 pass overall, Pint
clean.

## Notes for review

- The counters are what make the completion lines longer than a bare
  `Log::info('Statsim sync complete')`. Happy to strip them back if you would rather
  the lines were minimal, though they are what makes the line useful for spotting a
  sync that ran but stopped doing work.
- Unrelated latent bug, not fixed here: `VatusaFacilityInfoDTO` only initialises its
  typed `$roles` property inside its loop, so an empty roles array leaves it
  uninitialised and `Staff::fromFacilityInfoDTO` fatals. Worked around in the test
  fixture. Probably worth its own issue.
