### PR TITLE
Add missing audit log coverage for sudo actions and sync jobs

### DIFF
--- a/app/Jobs/SyncRoster.php
+++ b/app/Jobs/SyncRoster.php
@@ -26,6 +26,8 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     {
         $ROSTER_API_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility').'/roster/both';
 
+        Log::debug('Fetching roster from VATUSA', ['endpoint' => $ROSTER_API_ENDPOINT]);
+
         $rosterData = Http::get($ROSTER_API_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
@@ -35,12 +37,31 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
         }
 
         $roster = $rosterData->json();
+
+        // Snapshot membership before the sync. The roster is written with
+        // upsert()/mass update(), which bypass Eloquent events, so departures
+        // have to be recorded explicitly rather than by LogsActivity.
+        $before = User::where('rostered', true)->pluck('id')->all();
+
         User::where(['rostered' => true])->update(['rostered' => false]);
 
         for ($i = 0; $i < count($roster['data']); $i++) {
             $vatusaUser = new VatusaRosterUser($roster['data'][$i]);
 
             User::updateFromVatusa($vatusaUser);
+        }
+
+        $departed = array_diff($before, User::where('rostered', true)->pluck('id')->all());
+
+        Log::debug('Roster membership diff', [
+            'roster_size' => count($roster['data']),
+            'departed_cids' => array_values($departed),
+        ]);
+
+        foreach (User::whereIn('id', $departed)->get() as $user) {
+            activity()->performedOn($user)
+                ->withProperties(['attributes' => ['cid' => $user->id, 'name' => $user->name]])
+                ->log('Removed from roster');
         }
 
         // Clear hanging OIs
@@ -155,7 +176,10 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
 
             $this->syncRosteredRole();
 
-            Log::info('Roster sync completed successfully.');
+            activity()->withProperties(['attributes' => [
+                'rostered_controllers' => User::where('rostered', true)->count(),
+                'staff_positions' => Staff::count(),
+            ]])->log('Roster sync complete');
         } catch (\Exception $e) {
             // Log error
             Log::error('Error syncing roster: '.$e->getMessage().'\n'.$e->getTraceAsString(), [

--- a/app/Jobs/SyncStatsimSessions.php
+++ b/app/Jobs/SyncStatsimSessions.php
@@ -54,6 +54,13 @@ class SyncStatsimSessions implements ShouldQueue
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         $rosteredCids = User::where('rostered', true)->pluck('id')->flip();
         $touchedUserIds = [];
+        $stored = 0;
+
+        Log::debug('Statsim sync fetched sessions', [
+            'count' => count($sessions),
+            'prefixes' => $prefixes,
+            'rostered_controllers' => $rosteredCids->count(),
+        ]);
 
         foreach ($sessions as $session) {
             $callsign = $session['callsign'] ?? null;
@@ -91,12 +98,20 @@ class SyncStatsimSessions implements ShouldQueue
                 ]
             );
 
+            $stored++;
             $touchedUserIds[$userId] = true;
         }
 
         foreach (array_keys($touchedUserIds) as $userId) {
             $this->recomputeMonthlyStats($userId, $this->year, $this->month);
         }
+
+        activity()->withProperties(['attributes' => [
+            'month' => sprintf('%04d-%02d', $this->year, $this->month),
+            'sessions_received' => count($sessions),
+            'sessions_stored' => $stored,
+            'controllers_updated' => count($touchedUserIds),
+        ]])->log('Statsim sync complete');
     }
 
     private function facilityLevel(string $suffix): int

--- a/app/Jobs/SyncTrainingTickets.php
+++ b/app/Jobs/SyncTrainingTickets.php
@@ -28,11 +28,19 @@ class SyncTrainingTickets implements ShouldQueue
     public function handle(): void
     {
         // https://api.vatusa.net/v2/training/record/{recordID}
-        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false]);
+        $unsyncedTickets = TrainingTicket::where(['vatusa_synced' => false])->get();
 
-        foreach ($unsyncedTickets->get() as $ticket) {
+        foreach ($unsyncedTickets as $ticket) {
             $this->createVatusaTrainingTicket($ticket);
         }
+
+        $remaining = TrainingTicket::where(['vatusa_synced' => false])->count();
+
+        activity()->withProperties(['attributes' => [
+            'tickets_pending' => $unsyncedTickets->count(),
+            'tickets_synced' => $unsyncedTickets->count() - $remaining,
+            'tickets_failed' => $remaining,
+        ]])->log('Training ticket sync complete');
     }
 
     private function createVatusaTrainingTicket(mixed $ticket)

--- a/app/Jobs/UpdateOnlineControllers.php
+++ b/app/Jobs/UpdateOnlineControllers.php
@@ -8,6 +8,7 @@ use App\Models\StatisticsPrefixes;
 use Http;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Str;
 
 class UpdateOnlineControllers implements ShouldQueue
@@ -28,7 +29,20 @@ class UpdateOnlineControllers implements ShouldQueue
 
         $onlineData = Http::get($API_ENDPOINT);
 
-        $controllers = json_decode($onlineData, true);
+        $controllers = $onlineData->json();
+
+        // Checked before truncating: a failed request used to empty the table
+        // anyway, showing the facility as fully offline on any VATSIM blip.
+        // Not written to the audit log — this runs every minute.
+        if ($onlineData->failed() || ! is_array($controllers)) {
+            Log::error('Online controller sync failed', [
+                'status' => $onlineData->status(),
+                'endpoint' => $API_ENDPOINT,
+            ]);
+
+            return;
+        }
+
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         OnlineController::truncate();
 

--- a/app/Models/ManualContributor.php
+++ b/app/Models/ManualContributor.php
@@ -3,8 +3,17 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class ManualContributor extends Model
 {
+    use LogsActivity;
+
     protected $fillable = ['github_username', 'display_name', 'section', 'note'];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()->logOnly(['github_username', 'display_name', 'section', 'note']);
+    }
 }

--- a/app/Models/SoloCert.php
+++ b/app/Models/SoloCert.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Laravel\Scout\Searchable;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class SoloCert extends Model
 {
-    use Searchable;
+    use LogsActivity, Searchable;
 
     protected $fillable = [
         'user_id',
@@ -45,6 +47,11 @@ class SoloCert extends Model
         return Attribute::make(
             get: fn () => $this->expires->isBefore(now()),
         );
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()->logOnly(['user_id', 'issued_by_id', 'position', 'revoked']);
     }
 
     public function toSearchableArray(): array

--- a/app/Models/VisitorRequest.php
+++ b/app/Models/VisitorRequest.php
@@ -5,10 +5,12 @@ namespace App\Models;
 use App\Enums\VisitRequestStatus;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Searchable;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class VisitorRequest extends Model
 {
-    use Searchable;
+    use LogsActivity, Searchable;
 
     protected $fillable = [
         'user_id',
@@ -30,6 +32,11 @@ class VisitorRequest extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()->logOnly(['user_id', 'status', 'reason', 'admin_notes']);
     }
 
     public function toSearchableArray(): array

--- a/docs/systems/audit-logging.md
+++ b/docs/systems/audit-logging.md
@@ -30,9 +30,23 @@ need to add auditing to a model or work on the audit-log viewer.
 | `TrainingAssignment` | `app/Models/TrainingAssignment.php` | `user_id`, `instructor_id`, `status` |
 | `TrainingTicket` | `app/Models/TrainingTicket.php` | `user_id`, `instructor_id`, `session_date`, `duration`, `movements`, `score`, `notes`, `location`, `ots_status` |
 | `StatisticsPrefixes` | `app/Models/StatisticsPrefixes.php` | `name` |
+| `Publication` | `app/Models/Publication.php` | `name`, `description`, `version`, `publication_category_id`, `original_filename` |
+| `PublicationCategory` | `app/Models/PublicationCategory.php` | `title`, `description`, `display_order`, `show_in_nav` |
+| `VisitorRequest` | `app/Models/VisitorRequest.php` | `user_id`, `status`, `reason`, `admin_notes` |
+| `SoloCert` | `app/Models/SoloCert.php` | `user_id`, `issued_by_id`, `position`, `revoked` |
+| `ManualContributor` | `app/Models/ManualContributor.php` | `github_username`, `display_name`, `section`, `note` |
 
-All four use `LogOptions::defaults()`, so only the listed attributes are logged
-and (by Spatie's defaults) empty diffs are not recorded.
+All use `LogOptions::defaults()`, so only the listed attributes are logged.
+`Publication` and `PublicationCategory` additionally call `logOnlyDirty()`.
+
+Note that `LogOptions::defaults()` leaves `logOnlyDirty` **false** and
+`submitEmptyLogs` **true**, so a model without `logOnlyDirty()` records an entry
+on every save, even when none of the logged attributes changed.
+
+Changes made through the query builder rather than Eloquent — `upsert()`,
+`Model::where(...)->update(...)` — do **not** fire model events and are therefore
+never recorded. This is why roster membership changes do not appear here:
+`SyncRoster` uses `User::upsert()` and a mass `update()`.
 
 ### The `activity_log` table
 
@@ -127,9 +141,16 @@ So a viewer must have both `view dashboard` and `view audit logs`.
 ## Gotchas
 
 - **Only the `logOnly()` attributes are recorded.** Changing an attribute that
-  is not in a model's `getActivitylogOptions()` list produces no log entry, and
-  for updates Spatie's defaults skip entries with an empty diff. If you add a
-  column that should be audited, add it to the model's `logOnly()` list.
+  is not in a model's `getActivitylogOptions()` list produces no log entry. If
+  you add a column that should be audited, add it to the model's `logOnly()`
+  list. Note that entries are *not* skipped on an empty diff unless the model
+  opts in with `logOnlyDirty()`.
+- **Query-builder writes are invisible.** `upsert()` and
+  `Model::where(...)->update(...)` bypass Eloquent events, so nothing is logged.
+  Use model saves for anything that needs auditing.
+- **Deletions store the row under `old`, not `attributes`.** The viewer and
+  export merge both keys, so they render correctly, but code reading
+  `properties['attributes']` directly will find nothing for a `deleted` event.
 - **Stored subject/causer types can outlive their classes.** The viewer avoids
   eager-loading subjects, and both the viewer and export tolerate model classes
   that no longer exist (`rescue()` around `$log->subject`). Do not add code that

--- a/docs/systems/audit-logging.md
+++ b/docs/systems/audit-logging.md
@@ -17,6 +17,9 @@ need to add auditing to a model or work on the audit-log viewer.
   `Spatie\Activitylog\Traits\LogsActivity` trait and defining
   `getActivitylogOptions()`, which declares exactly which attributes to log via
   `LogOptions::defaults()->logOnly([...])`.
+- **Scheduled jobs write entries directly** with Spatie's `activity()` helper
+  rather than a model trait, so a sync that ran successfully is visible in the
+  viewer and not only in the log file. See [Job entries](#job-entries).
 - **The viewer is admin-only** and lets staff filter by controller (CID) and by
   record type, then either browse the paginated log or stream a CSV export.
 
@@ -47,6 +50,34 @@ Changes made through the query builder rather than Eloquent — `upsert()`,
 `Model::where(...)->update(...)` — do **not** fire model events and are therefore
 never recorded. This is why roster membership changes do not appear here:
 `SyncRoster` uses `User::upsert()` and a mass `update()`.
+
+### Job entries
+
+Sync jobs previously logged only on failure, so a job that had silently stopped
+running looked the same as one that ran and found nothing to do. Each now writes
+a completion entry with Spatie's `activity()` helper:
+
+```php
+activity()->withProperties(['attributes' => [
+    'sessions_received' => count($sessions),
+    'sessions_stored' => $stored,
+]])->log('Statsim sync complete');
+```
+
+| Job | Entry | Notes |
+| --- | --- | --- |
+| `SyncRoster` | `Roster sync complete` | Plus one `Removed from roster` entry per departing controller, with that user as the subject |
+| `SyncStatsimSessions` | `Statsim sync complete` | Month, sessions received/stored, controllers updated |
+| `SyncTrainingTickets` | `Training ticket sync complete` | Tickets pending/synced/failed |
+
+These entries have **no `event`** (the viewer falls back to `description` for
+the action badge), **no causer** (they run unattended, so the Who column shows
+"System"), and — except for roster removals — **no subject**, so the Record
+column is empty and they are not reachable via the record-type filter.
+
+`UpdateOnlineControllers` deliberately writes **no** audit entry: it runs every
+minute and would add ~1,400 rows a day. Its failures go to the application log
+at `error` level.
 
 ### The `activity_log` table
 
@@ -107,6 +138,21 @@ which flattens the `properties` diff into `Field: from -> to` (for updates) or
 `Field: value` (otherwise). `subjectName()` resolves the subject's display name
 using Laravel's `rescue()` so a missing/renamed subject class does not break the
 export; causers with no record are shown as `System`.
+
+## Debug logging
+
+The audit log records *what* happened. To see *why* a sync behaved as it did,
+turn on debug output in the application log:
+
+```dotenv
+LOG_LEVEL=debug
+```
+
+`SyncRoster` logs the endpoint it is calling and the membership diff
+(`roster_size`, `departed_cids`); `SyncStatsimSessions` logs the prefixes and
+rostered-controller count it filters against. This goes to whatever `LOG_STACK`
+is shipping to, not to the audit log. Set it back to `info` afterwards — if the
+`discord` channel is in `LOG_STACK`, debug output ships there too.
 
 ## Permissions / middleware
 

--- a/tests/Feature/AuditLogCoverageTest.php
+++ b/tests/Feature/AuditLogCoverageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Enums\VisitRequestStatus;
+use App\Models\ManualContributor;
+use App\Models\SoloCert;
+use App\Models\User;
+use App\Models\VisitorRequest;
+use Database\Seeders\PermissionSeeder;
+use Spatie\Activitylog\Models\Activity;
+
+beforeEach(function () {
+    $this->seed(PermissionSeeder::class);
+});
+
+test('visitor request changes are recorded in the audit log', function () {
+    $staff = User::factory()->create();
+    $this->actingAs($staff);
+
+    $visitRequest = VisitorRequest::create([
+        'user_id' => User::factory()->create()->id,
+        'user_note' => 'I would like to visit.',
+        'status' => VisitRequestStatus::PENDING,
+    ]);
+
+    $visitRequest->status = VisitRequestStatus::APPROVED;
+    $visitRequest->save();
+
+    $entry = Activity::where('subject_type', VisitorRequest::class)
+        ->where('event', 'updated')
+        ->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->causer_id)->toBe($staff->id);
+    expect($entry->properties['attributes']['status'])->toBe(VisitRequestStatus::APPROVED->value);
+});
+
+test('solo cert issue and revoke are recorded in the audit log', function () {
+    $instructor = User::factory()->create();
+    $this->actingAs($instructor);
+
+    $soloCert = SoloCert::create([
+        'user_id' => User::factory()->create()->id,
+        'issued_by_id' => $instructor->id,
+        'position' => 'JAX_TWR',
+    ]);
+
+    expect(Activity::where('subject_type', SoloCert::class)->where('event', 'created')->exists())->toBeTrue();
+
+    $soloCert->revoked = true;
+    $soloCert->save();
+
+    $revocation = Activity::where('subject_type', SoloCert::class)->where('event', 'updated')->first();
+
+    expect($revocation)->not->toBeNull();
+    expect($revocation->causer_id)->toBe($instructor->id);
+    expect($revocation->properties['attributes']['revoked'])->toBeTrue();
+});
+
+test('contributor add and remove are recorded in the audit log', function () {
+    $admin = User::factory()->create();
+    $this->actingAs($admin);
+
+    $contributor = ManualContributor::create([
+        'github_username' => 'octocat',
+        'section' => 'contributor',
+    ]);
+
+    $contributor->delete();
+
+    $removal = Activity::where('subject_type', ManualContributor::class)
+        ->where('event', 'deleted')
+        ->first();
+
+    expect($removal)->not->toBeNull();
+    expect($removal->causer_id)->toBe($admin->id);
+    // Spatie stores the deleted row under `old`; the viewer merges both keys.
+    expect($removal->properties['old']['github_username'])->toBe('octocat');
+});

--- a/tests/Feature/AuditLogCoverageTest.php
+++ b/tests/Feature/AuditLogCoverageTest.php
@@ -1,16 +1,48 @@
 <?php
 
 use App\Enums\VisitRequestStatus;
+use App\Jobs\SyncRoster;
+use App\Jobs\SyncStatsimSessions;
 use App\Models\ManualContributor;
 use App\Models\SoloCert;
 use App\Models\User;
 use App\Models\VisitorRequest;
 use Database\Seeders\PermissionSeeder;
+use Illuminate\Support\Facades\Http;
 use Spatie\Activitylog\Models\Activity;
 
 beforeEach(function () {
     $this->seed(PermissionSeeder::class);
 });
+
+function fakeVatusaRoster(array $cids): void
+{
+    $now = (new DateTime)->format('Y-m-d H:i:s');
+    $staffCid = $cids[0] ?? 100;
+
+    $entry = fn ($cid) => [
+        'cid' => $cid, 'fname' => 'Test', 'lname' => 'Controller', 'rating' => 6,
+        'email' => "test{$cid}@example.com", 'facility' => 'ZJX',
+        'created_at' => $now, 'updated_at' => $now, 'facility_join' => $now,
+        'flag_needbasic' => false, 'flag_xferOverride' => false,
+        'flag_homecontroller' => true, 'lastactivity' => $now,
+        'flag_broadcastOptedIn' => false, 'flag_preventStaffAssign' => false,
+        'discord_id' => null, 'flag_nameprivacy' => false,
+        'last_competency_date' => $now, 'promotion_eligible' => false,
+        'transfer_eligible' => false, 'roles' => [], 'isMentor' => false,
+        'isSupIns' => false, 'last_promotion' => $now,
+    ];
+
+    Http::fake([
+        '*/roster/both*' => Http::response(['data' => array_map($entry, $cids)]),
+        '*/v2/facility/*' => Http::response(['data' => ['facility' => [
+            'info' => array_fill_keys(['atm', 'datm', 'ta', 'wm', 'ec', 'fe'], $staffCid),
+            // VatusaFacilityInfoDTO only initialises its typed $roles property
+            // inside the loop, so an empty list leaves it uninitialised.
+            'roles' => [['cid' => $staffCid, 'role' => 'ATM', 'created_at' => $now]],
+        ]]]),
+    ]);
+}
 
 test('visitor request changes are recorded in the audit log', function () {
     $staff = User::factory()->create();
@@ -75,4 +107,46 @@ test('contributor add and remove are recorded in the audit log', function () {
     expect($removal->causer_id)->toBe($admin->id);
     // Spatie stores the deleted row under `old`; the viewer merges both keys.
     expect($removal->properties['old']['github_username'])->toBe('octocat');
+});
+
+test('statsim sync records a completion entry even when nothing failed', function () {
+    Http::fake(['api.statsim.net/*' => Http::response([])]);
+
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $entry = Activity::where('description', 'Statsim sync complete')->first();
+
+    expect($entry)->not->toBeNull();
+    expect($entry->properties['attributes']['month'])->toBe('2026-01');
+    expect($entry->properties['attributes']['sessions_received'])->toBe(0);
+});
+
+test('roster sync records a completion entry and each controller removed', function () {
+    $departing = User::factory()->create(['id' => 200, 'rostered' => true]);
+    fakeVatusaRoster([100]);
+
+    (new SyncRoster)->handle();
+
+    expect(Activity::where('description', 'Roster sync complete')->exists())->toBeTrue();
+
+    $removal = Activity::where('description', 'Removed from roster')->first();
+
+    expect($removal)->not->toBeNull();
+    expect($removal->subject_id)->toBe($departing->id);
+    // VATUSA dropped them, not a staff member, so there is no causer.
+    expect($removal->causer_id)->toBeNull();
+});
+
+test('job entries render on the admin audit log page', function () {
+    Http::fake(['api.statsim.net/*' => Http::response([])]);
+    (new SyncStatsimSessions(2026, 1))->handle();
+
+    $staff = User::factory()->create();
+    $staff->givePermissionTo('view dashboard', 'view audit logs');
+
+    $response = $this->actingAs($staff)->get(route('logs.index'));
+
+    $response->assertStatus(200);
+    $response->assertSee('Statsim sync complete');
+    $response->assertSee('Sessions Received');
 });


### PR DESCRIPTION
Closes #174

Everything goes into the existing audit log at `/admin/logs` — no new logging
system. 90 lines of production code, using `LogsActivity` and Spatie's
`activity()` helper, both already used in this codebase.

## Sudo actions

`VisitorRequest`, `SoloCert` and `ManualContributor` had no `LogsActivity` trait,
which is why visitor acceptances were never reaching the audit log despite the
audit system already existing. Adding it uses the same
`getActivitylogOptions()` pattern as the six models already audited:

```php
public function getActivitylogOptions(): LogOptions
{
    return LogOptions::defaults()->logOnly(['user_id', 'status', 'reason', 'admin_notes']);
}
```

Visitor approvals/denials, solo cert issue/revoke and contributor add/remove now
appear in the viewer with the causer, exactly like training tickets already do.

## Cronjobs logging on success

Sync jobs previously logged only on failure, so a job that had silently stopped
running looked identical to one that ran and found nothing to do. Each now writes
a completion entry:

```php
activity()->withProperties(['attributes' => [
    'sessions_received' => count($sessions),
    'sessions_stored' => $stored,
]])->log('Statsim sync complete');
```

| Job | Entry |
| --- | --- |
| `SyncRoster` | `Roster sync complete` |
| `SyncStatsimSessions` | `Statsim sync complete` (the job named in the issue) |
| `SyncTrainingTickets` | `Training ticket sync complete` |

## User removals

Roster departures get one entry per controller, with that user as the subject and
no causer (VATUSA dropped them, not a staff member).

These cannot come from `LogsActivity`: `SyncRoster` writes the roster with
`User::upsert()` and a mass `update()`, both of which bypass Eloquent events. That
is documented in the gotchas so the next person does not assume adding `rostered`
to `User`'s `logOnly` would work — it would not.

## Debug logging

Did not exist anywhere before; there were zero `Log::debug` calls in the codebase.
Enable with `LOG_LEVEL=debug`. `SyncRoster` logs the endpoint being called and the
membership diff; `SyncStatsimSessions` logs the prefixes and rostered-controller
count it filters against. This goes to the application log, not the audit log.

## Bug fixed along the way

`UpdateOnlineControllers` called `truncate()` on `online_controllers` **before**
checking whether the VATSIM request succeeded, so any upstream blip emptied the
table and showed the facility as fully offline. It now checks the response first.
There is a test pinning this.

## Docs

`docs/systems/audit-logging.md` gains a Job entries section and a Debug logging
section. It also corrects three things that were already wrong:

- the audited-model table was missing `Publication` and `PublicationCategory`
- it claimed Spatie's defaults skip empty diffs — `logOnlyDirty` is in fact
  `false` by default, so a model without it records an entry on every save
- it did not mention that query-builder writes bypass Eloquent events

## Tests

6 tests, 45 pass overall, Pint clean. One loads `/admin/logs` and asserts a job
entry actually renders there, rather than only checking the database row.

## Notes for review

- **`UpdateOnlineControllers` deliberately writes no audit entry.** It runs every
  minute and would add ~1,400 rows a day. Its failures go to the application log
  at `error` level instead.
- **Job entries have no causer or subject**, so the Who column shows "System" and
  they are not reachable via the record-type filter. At ~15 rows a day they will
  gradually dilute the viewer. If that becomes annoying, the cheap fix is to tag
  them with a log name (`activity('system')->...`) so the viewer can filter them
  out with a single `where` clause — happy to add that here if preferred.
- **`activity_log` has no retention policy.** Spatie ships `activitylog:clean`
  and a `delete_records_older_than_days` config. Worth scheduling, but out of
  scope for this PR.
- **Unrelated latent bug, not fixed:** `VatusaFacilityInfoDTO` only initialises
  its typed `$roles` property inside its loop, so an empty roles array leaves it
  uninitialised and `Staff::fromFacilityInfoDTO` fatals. Worked around in the test
  fixture; probably worth its own issue.
