### PR TITLE
Feedback on Controller Profile / Feedback Email System

### DIFF
--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -6,6 +6,7 @@ use App\Enums\FeedbackExperience;
 use App\Enums\FeedbackStatus;
 use App\Jobs\SendFeedbackToWebhook;
 use App\Mail\FeedbackCommentPosted;
+use App\Mail\FeedbackReceived;
 use App\Mail\FeedbackReleased;
 use App\Models\Feedback;
 use App\Models\User;
@@ -62,6 +63,7 @@ class FeedbackController extends Controller
 
         SendFeedbackToWebhook::dispatch($feedback);
         Mail::to($feedback->user)->queue(new FeedbackReleased($feedback));
+        Mail::to($feedback->controller)->queue(new FeedbackReceived($feedback));
 
         return redirect()->route('admin.feedback.index')->with('success', 'Feedback released.');
     }

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -59,7 +59,17 @@ class FeedbackController extends Controller
 
     public function release(Feedback $feedback)
     {
-        $feedback->update(['status' => FeedbackStatus::RELEASED]);
+        // Conditional update so concurrent submits can't both win the race and
+        // double-send the webhook and emails.
+        $claimed = Feedback::whereKey($feedback->getKey())
+            ->where('status', '!=', FeedbackStatus::RELEASED)
+            ->update(['status' => FeedbackStatus::RELEASED]);
+
+        if ($claimed === 0) {
+            return redirect()->route('admin.feedback.index')->with('error', 'That feedback has already been released.');
+        }
+
+        $feedback->refresh();
 
         SendFeedbackToWebhook::dispatch($feedback);
         Mail::to($feedback->user)->queue(new FeedbackReleased($feedback));
@@ -97,6 +107,10 @@ class FeedbackController extends Controller
 
     public function store(Request $request)
     {
+        if ($request->user()->hasRole('rostered')) {
+            abort(403, 'Rostered controllers cannot submit feedback.');
+        }
+
         $validated = $request->validate([
             'controller_id' => ['required', Rule::exists('users', 'id')->where('rostered', true)],
             'position' => ['required', 'string', 'max:255'],

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -5,20 +5,29 @@ namespace App\Http\Controllers;
 use App\Enums\FeedbackExperience;
 use App\Enums\FeedbackStatus;
 use App\Jobs\SendFeedbackToWebhook;
+use App\Mail\FeedbackCommentPosted;
+use App\Mail\FeedbackReleased;
 use App\Models\Feedback;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rule;
 
 class FeedbackController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
         $controllers = User::where('rostered', true)->orderBy('last_name')->get();
+
+        $myFeedback = Feedback::where('user_id', $request->user()->id)
+            ->with(['controller', 'visibleComments.user'])
+            ->orderBy('created_at', 'desc')
+            ->get();
 
         return view('feedback.index', [
             'controllers' => $controllers,
             'experiences' => FeedbackExperience::cases(),
+            'myFeedback' => $myFeedback,
         ]);
     }
 
@@ -52,6 +61,7 @@ class FeedbackController extends Controller
         $feedback->update(['status' => FeedbackStatus::RELEASED]);
 
         SendFeedbackToWebhook::dispatch($feedback);
+        Mail::to($feedback->user)->queue(new FeedbackReleased($feedback));
 
         return redirect()->route('admin.feedback.index')->with('success', 'Feedback released.');
     }
@@ -67,12 +77,18 @@ class FeedbackController extends Controller
     {
         $validated = $request->validate([
             'comment' => ['required', 'string', 'max:5000'],
+            'user_visible' => ['nullable', 'boolean'],
         ]);
 
-        $feedback->staffComments()->create([
+        $comment = $feedback->staffComments()->create([
             'user_id' => $request->user()->id,
             'comment' => $validated['comment'],
+            'user_visible' => $request->boolean('user_visible'),
         ]);
+
+        if ($comment->user_visible) {
+            Mail::to($feedback->user)->queue(new FeedbackCommentPosted($comment));
+        }
 
         return redirect()->route('admin.feedback.show', [$feedback])->with('success', 'Comment posted.');
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\FeedbackStatus;
 use App\Models\ControllerMonthlyStat;
 use App\Models\ControllerSession;
+use App\Models\Feedback;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -32,12 +34,18 @@ class UserController extends Controller
             ->limit(10)
             ->get();
 
+        $releasedFeedback = Feedback::where('controller_id', $id)
+            ->where('status', FeedbackStatus::RELEASED)
+            ->orderBy('created_at', 'desc')
+            ->paginate(5);
+
         return view('users.show', [
             'user' => $user,
             'totalHours' => $totalHours,
             'monthHours' => $monthHours,
             'yearHours' => $yearHours,
             'recentSessions' => $recentSessions,
+            'releasedFeedback' => $releasedFeedback,
         ]);
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -34,18 +34,12 @@ class UserController extends Controller
             ->limit(10)
             ->get();
 
-        $releasedFeedback = Feedback::where('controller_id', $id)
-            ->where('status', FeedbackStatus::RELEASED)
-            ->orderBy('created_at', 'desc')
-            ->paginate(5);
-
         return view('users.show', [
             'user' => $user,
             'totalHours' => $totalHours,
             'monthHours' => $monthHours,
             'yearHours' => $yearHours,
             'recentSessions' => $recentSessions,
-            'releasedFeedback' => $releasedFeedback,
         ]);
     }
 
@@ -118,6 +112,25 @@ class UserController extends Controller
         return view('users.training-assignments', [
             'user' => $user,
             'trainingAssignments' => $trainingAssignments,
+        ]);
+    }
+
+    public function feedback(int $id)
+    {
+        $user = User::findOrFail($id);
+
+        if (Auth::id() !== $user->id && ! Auth::user()->hasPermissionTo('feedback:read')) {
+            abort(403);
+        }
+
+        $releasedFeedback = Feedback::where('controller_id', $id)
+            ->where('status', FeedbackStatus::RELEASED)
+            ->orderBy('created_at', 'desc')
+            ->paginate(10);
+
+        return view('users.feedback', [
+            'user' => $user,
+            'releasedFeedback' => $releasedFeedback,
         ]);
     }
 

--- a/app/Mail/FeedbackCommentPosted.php
+++ b/app/Mail/FeedbackCommentPosted.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\FeedbackComment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class FeedbackCommentPosted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public FeedbackComment $comment)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'New Comment on Your Feedback',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.feedback-comment-posted',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/FeedbackReceived.php
+++ b/app/Mail/FeedbackReceived.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Feedback;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class FeedbackReceived extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Feedback $feedback)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'New Feedback Released for You',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.feedback-received',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/FeedbackReleased.php
+++ b/app/Mail/FeedbackReleased.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Feedback;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class FeedbackReleased extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Feedback $feedback)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Your Feedback Has Been Released',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.feedback-released',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -45,6 +45,11 @@ class Feedback extends Model
         return $this->hasMany(FeedbackComment::class)->orderBy('created_at');
     }
 
+    public function visibleComments()
+    {
+        return $this->hasMany(FeedbackComment::class)->where('user_visible', true)->orderBy('created_at');
+    }
+
     public function toSearchableArray(): array
     {
         return [

--- a/app/Models/FeedbackComment.php
+++ b/app/Models/FeedbackComment.php
@@ -10,6 +10,11 @@ class FeedbackComment extends Model
         'feedback_id',
         'user_id',
         'comment',
+        'user_visible',
+    ];
+
+    protected $casts = [
+        'user_visible' => 'boolean',
     ];
 
     public function feedback()

--- a/database/migrations/2026_08_06_000000_add_user_visible_to_feedback_comments_table.php
+++ b/database/migrations/2026_08_06_000000_add_user_visible_to_feedback_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('feedback_comments', function (Blueprint $table) {
+            $table->boolean('user_visible')->default(false)->after('comment');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('feedback_comments', function (Blueprint $table) {
+            $table->dropColumn('user_visible');
+        });
+    }
+};

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -5,6 +5,9 @@
 @section('body')
     <div class="max-w-2xl">
         <x-card-component title="Submit Feedback">
+            @hasrole('rostered')
+            <p class="text-lg mt-2">Rostered controllers cannot submit feedback.</p>
+            @else
             <p class="text-lg mb-4">Had a session with one of our controllers? Let us know how it went.</p>
 
             <form action="{{ route('feedback.store') }}" method="POST" class="flex flex-col gap-y-4">
@@ -71,6 +74,7 @@
 
                 <button type="submit" class="btn btn-primary w-max">Submit Feedback</button>
             </form>
+            @endhasrole
         </x-card-component>
 
         @unless ($myFeedback->isEmpty())

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -72,5 +72,49 @@
                 <button type="submit" class="btn btn-primary w-max">Submit Feedback</button>
             </form>
         </x-card-component>
+
+        @unless ($myFeedback->isEmpty())
+            <x-card-component title="Your Feedback" class="mt-5">
+                <div class="flex flex-col mt-2">
+                    @foreach ($myFeedback as $entry)
+                        <div class="border-b border-base-300 py-4 last:border-b-0">
+                            <div class="flex flex-row flex-wrap items-center gap-x-3 gap-y-1">
+                                <span class="font-semibold">{{ $entry->controller->name }}</span>
+                                <span class="font-mono">{{ $entry->position }}</span>
+                                <span class="badge
+                                    @if ($entry->status === \App\Enums\FeedbackStatus::RELEASED) badge-success
+                                    @else badge-neutral @endif">
+                                    {{ $entry->status === \App\Enums\FeedbackStatus::RELEASED ? 'Released' : 'Pending Review' }}
+                                </span>
+                                <span class="text-sm opacity-70">
+                                    <time data-local datetime="{{ $entry->created_at->toIso8601String() }}">
+                                        {{ $entry->created_at->timezone('America/New_York')->format('m-d-Y') }}
+                                    </time>
+                                </span>
+                            </div>
+
+                            <p class="mt-2 whitespace-pre-line">{{ $entry->comments }}</p>
+
+                            @unless ($entry->visibleComments->isEmpty())
+                                <div class="mt-3 pl-4 border-l-2 border-base-300 flex flex-col gap-y-3">
+                                    @foreach ($entry->visibleComments as $comment)
+                                        <div>
+                                            <div class="flex flex-row flex-wrap items-center gap-x-2 text-sm opacity-70">
+                                                <span class="font-semibold">Staff comment</span>
+                                                <span>&middot;</span>
+                                                <time data-local datetime="{{ $comment->created_at->toIso8601String() }}">
+                                                    {{ $comment->created_at->timezone('America/New_York')->format('m-d-Y g:i A') }} ET
+                                                </time>
+                                            </div>
+                                            <p class="mt-1 whitespace-pre-line">{{ $comment->comment }}</p>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            @endunless
+                        </div>
+                    @endforeach
+                </div>
+            </x-card-component>
+        @endunless
     </div>
 @endsection

--- a/resources/views/layouts/profile.blade.php
+++ b/resources/views/layouts/profile.blade.php
@@ -13,6 +13,13 @@
 
                     @auth
                     @php($isOwner = Auth::id() == $user->id)
+                    @if($isOwner || Auth::user()->can('feedback:read'))
+                    <a
+                    role="tab"
+                    href='{{ route("users.show.feedback", $user) }}'
+                    @class(['tab whitespace-nowrap', 'tab-active' => request()->routeIs('users.show.feedback')])
+                    >Feedback</a>
+                    @endif
                     @if($isOwner || Auth::user()->can('training-tickets:read'))
                     <a
                     role="tab"

--- a/resources/views/mail/feedback-comment-posted.blade.php
+++ b/resources/views/mail/feedback-comment-posted.blade.php
@@ -1,0 +1,11 @@
+@extends('mail.layout')
+
+@section('content')
+    <p>Hello {{ $comment->feedback->user->first_name }},</p>
+
+    <p>A staff member has left a comment on the feedback you submitted about <strong>{{ $comment->feedback->controller->name }}</strong> on <strong>{{ $comment->feedback->position }}</strong>:</p>
+
+    <p style="background-color: #F3F4F6; padding: 16px; border-radius: 0.25rem; white-space: pre-line;">{{ $comment->comment }}</p>
+
+    <p>You can view your feedback and all staff comments on the <a style='color: blue; text-decoration: underline;' href="{{ route('feedback.index') }}">feedback page</a>.</p>
+@endsection

--- a/resources/views/mail/feedback-received.blade.php
+++ b/resources/views/mail/feedback-received.blade.php
@@ -1,0 +1,15 @@
+@extends('mail.layout')
+
+@section('content')
+    <p>Hello {{ $feedback->controller->first_name }},</p>
+
+    <p>Feedback about your session on <strong>{{ $feedback->position }}</strong> has just been released and is now visible on your controller profile.</p>
+
+    <p><strong>Experience:</strong> {{ $feedback->experience->value }}</p>
+
+    <p style="background-color: #F3F4F6; padding: 16px; border-radius: 0.25rem; white-space: pre-line;">{{ $feedback->comments }}</p>
+
+    <p>You can view all of your released feedback on <a style='color: blue; text-decoration: underline;' href="{{ route('users.show', [$feedback->controller_id]) }}">your profile</a>.</p>
+
+    <p>Keep up the great work!</p>
+@endsection

--- a/resources/views/mail/feedback-received.blade.php
+++ b/resources/views/mail/feedback-received.blade.php
@@ -9,7 +9,7 @@
 
     <p style="background-color: #F3F4F6; padding: 16px; border-radius: 0.25rem; white-space: pre-line;">{{ $feedback->comments }}</p>
 
-    <p>You can view all of your released feedback on <a style='color: blue; text-decoration: underline;' href="{{ route('users.show', [$feedback->controller_id]) }}">your profile</a>.</p>
+    <p>You can view all of your released feedback on <a style='color: blue; text-decoration: underline;' href="{{ route('users.show.feedback', [$feedback->controller_id]) }}">your profile</a>.</p>
 
     <p>Keep up the great work!</p>
-@endsection
+@endsection2

--- a/resources/views/mail/feedback-released.blade.php
+++ b/resources/views/mail/feedback-released.blade.php
@@ -1,0 +1,11 @@
+@extends('mail.layout')
+
+@section('content')
+    <p>Hello {{ $feedback->user->first_name }},</p>
+
+    <p>Your feedback about <strong>{{ $feedback->controller->name }}</strong> on <strong>{{ $feedback->position }}</strong> has been reviewed and released by our staff. It is now visible on the controller's profile.</p>
+
+    <p>You can review your submitted feedback and any staff comments on the <a style='color: blue; text-decoration: underline;' href="{{ route('feedback.index') }}">feedback page</a>.</p>
+
+    <p>Thank you for taking the time to share your experience!</p>
+@endsection

--- a/resources/views/manage-feedback/show.blade.php
+++ b/resources/views/manage-feedback/show.blade.php
@@ -122,6 +122,9 @@
                                     <a href="{{ route('users.show', [$comment->user_id]) }}" class="font-semibold link link-hover">
                                         {{ $comment->user->name }} - {{ $comment->user_id }}
                                     </a>
+                                    @if ($comment->user_visible)
+                                        <span class="badge badge-info badge-sm">Visible to submitter</span>
+                                    @endif
                                 </div>
                                 <p class="mt-1 whitespace-pre-line">{{ $comment->comment }}</p>
                             </div>
@@ -139,6 +142,10 @@
                         @error('comment')
                             <span class="text-error text-sm">{{ $message }}</span>
                         @enderror
+                        <label class="flex items-center gap-x-2 cursor-pointer w-max">
+                            <input type="checkbox" name="user_visible" value="1" class="checkbox checkbox-sm" @checked(old('user_visible'))>
+                            <span class="text-sm">Visible to submitter (sends an email notification)</span>
+                        </label>
                         <span class="text-sm opacity-60">Press Enter to post &middot; Shift+Enter for a new line</span>
                     </form>
                     @endhaspermission

--- a/resources/views/users/feedback.blade.php
+++ b/resources/views/users/feedback.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.profile')
+
+@section('profile-content')
+    <x-card-component title='Feedback'>
+        @if($releasedFeedback->isEmpty())
+            <p class='text-base mt-2'>No feedback yet.</p>
+        @else
+            <div class='flex flex-col mt-2'>
+                @foreach($releasedFeedback as $entry)
+                    <div class='border-b border-base-300 py-4 last:border-b-0'>
+                        <div class='flex flex-row flex-wrap items-center gap-x-3 gap-y-1'>
+                            <span class='badge badge-neutral'>{{ $entry->experience->value }}</span>
+                            <span class='font-mono font-semibold'>{{ $entry->position }}</span>
+                            <span class='text-sm opacity-70'>
+                                <time data-local datetime="{{ $entry->created_at->toIso8601String() }}">
+                                    {{ $entry->created_at->timezone('America/New_York')->format('m-d-Y') }}
+                                </time>
+                            </span>
+                        </div>
+                        <p class='mt-2 whitespace-pre-line'>{{ $entry->comments }}</p>
+                    </div>
+                @endforeach
+            </div>
+
+            <div class='mt-3'>
+                {{ $releasedFeedback->links() }}
+            </div>
+        @endif
+    </x-card-component>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -54,32 +54,5 @@
             </div>
         @endif
     </x-card-component>
-
-    <x-card-component title='Feedback'>
-        @if($releasedFeedback->isEmpty())
-            <p class='text-base mt-2'>No feedback yet.</p>
-        @else
-            <div class='flex flex-col mt-2'>
-                @foreach($releasedFeedback as $entry)
-                    <div class='border-b border-base-300 py-4 last:border-b-0'>
-                        <div class='flex flex-row flex-wrap items-center gap-x-3 gap-y-1'>
-                            <span class='badge badge-neutral'>{{ $entry->experience->value }}</span>
-                            <span class='font-mono font-semibold'>{{ $entry->position }}</span>
-                            <span class='text-sm opacity-70'>
-                                <time data-local datetime="{{ $entry->created_at->toIso8601String() }}">
-                                    {{ $entry->created_at->timezone('America/New_York')->format('m-d-Y') }}
-                                </time>
-                            </span>
-                        </div>
-                        <p class='mt-2 whitespace-pre-line'>{{ $entry->comments }}</p>
-                    </div>
-                @endforeach
-            </div>
-
-            <div class='mt-3'>
-                {{ $releasedFeedback->links() }}
-            </div>
-        @endif
-    </x-card-component>
 </div>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -54,5 +54,32 @@
             </div>
         @endif
     </x-card-component>
+
+    <x-card-component title='Feedback'>
+        @if($releasedFeedback->isEmpty())
+            <p class='text-base mt-2'>No feedback yet.</p>
+        @else
+            <div class='flex flex-col mt-2'>
+                @foreach($releasedFeedback as $entry)
+                    <div class='border-b border-base-300 py-4 last:border-b-0'>
+                        <div class='flex flex-row flex-wrap items-center gap-x-3 gap-y-1'>
+                            <span class='badge badge-neutral'>{{ $entry->experience->value }}</span>
+                            <span class='font-mono font-semibold'>{{ $entry->position }}</span>
+                            <span class='text-sm opacity-70'>
+                                <time data-local datetime="{{ $entry->created_at->toIso8601String() }}">
+                                    {{ $entry->created_at->timezone('America/New_York')->format('m-d-Y') }}
+                                </time>
+                            </span>
+                        </div>
+                        <p class='mt-2 whitespace-pre-line'>{{ $entry->comments }}</p>
+                    </div>
+                @endforeach
+            </div>
+
+            <div class='mt-3'>
+                {{ $releasedFeedback->links() }}
+            </div>
+        @endif
+    </x-card-component>
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,8 +30,13 @@ use App\Jobs\SyncRoster;
 use App\Jobs\SyncTrainingTickets;
 use App\Jobs\UpdateOnlineControllers;
 use App\Livewire\EventRegistration;
+use App\Mail\FeedbackCommentPosted;
+use App\Mail\FeedbackReceived;
+use App\Mail\FeedbackReleased;
 use App\Mail\TrainingAssignmentCreated;
 use App\Mail\Welcome;
+use App\Models\Feedback;
+use App\Models\FeedbackComment;
 use App\Models\TrainingAssignment;
 use App\Models\User;
 use Illuminate\Support\Facades\App;
@@ -221,4 +226,10 @@ if (App::environment('development', 'local')) {
 
         return new TrainingAssignmentCreated(TrainingAssignment::find(1));
     });
+
+    Route::get('/test-email/feedback-released', fn () => new FeedbackReleased(Feedback::latest()->firstOrFail()));
+
+    Route::get('/test-email/feedback-comment', fn () => new FeedbackCommentPosted(FeedbackComment::latest()->firstOrFail()));
+
+    Route::get('/test-email/feedback-received', fn () => new FeedbackReceived(Feedback::latest()->firstOrFail()));
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::get('/auth/logout', [VatsimOauthController::class, 'logout'])->name('auth
 Route::resource('users', UserController::class, ['only' => ['show', 'edit', 'update']]);
 Route::prefix('users/{user}')->group(function () {
     Route::get('/', [UserController::class, 'show'])->name('users.show');
+    Route::get('feedback', [UserController::class, 'feedback'])->middleware('auth')->name('users.show.feedback');
     Route::get('training-tickets', [UserController::class, 'trainingTickets'])->middleware('auth')->name('users.show.training-tickets');
     Route::get('training-assignments', [UserController::class, 'trainingAssignments'])->middleware('auth')->name('users.show.training-assignments');
     Route::get('solo-certs', [UserController::class, 'soloCerts'])->middleware('auth')->name('users.show.solo-certs');

--- a/tests/Feature/FeedbackTest.php
+++ b/tests/Feature/FeedbackTest.php
@@ -207,6 +207,24 @@ test('given an admin, when releasing feedback, then its status becomes released 
     Queue::assertPushed(SendFeedbackToWebhook::class, fn ($job) => $job->feedback->is($feedback));
 });
 
+test('given already released feedback, when releasing it again, then no webhook or emails are re-sent', function () {
+    Queue::fake();
+    Mail::fake();
+
+    $admin = User::factory()->create();
+    $admin->assignRole(['staff', 'admin']);
+
+    $feedback = Feedback::factory()->create(['status' => FeedbackStatus::RELEASED]);
+
+    $response = $this->actingAs($admin)->put(route('admin.feedback.release', $feedback));
+
+    $response->assertRedirect(route('admin.feedback.index'));
+    $response->assertSessionHas('error');
+    expect($feedback->fresh()->status)->toBe(FeedbackStatus::RELEASED);
+    Queue::assertNotPushed(SendFeedbackToWebhook::class);
+    Mail::assertNothingQueued();
+});
+
 test('given a non-admin user, when stashing feedback, then the request is forbidden and the status is unchanged', function () {
     $user = User::factory()->create();
     $user->assignRole('rostered');
@@ -272,14 +290,14 @@ test('given an admin, when posting an empty staff comment, then a comment error 
 
 // Feedback on controller profile
 
-test('given released feedback, when visiting the controller profile, then the feedback is shown without the submitter identity', function () {
+test('given released feedback, when the controller views their own profile, then the feedback is shown without the submitter identity', function () {
     $feedback = Feedback::factory()->create([
         'position' => 'JAX_TWR',
         'comments' => 'Great service on tower frequency.',
         'status' => FeedbackStatus::RELEASED,
     ]);
 
-    $response = $this->get(route('users.show', [$feedback->controller_id]));
+    $response = $this->actingAs($feedback->controller)->get(route('users.show.feedback', [$feedback->controller_id]));
 
     $response->assertOk();
     $response->assertSee('Great service on tower frequency.');
@@ -287,7 +305,7 @@ test('given released feedback, when visiting the controller profile, then the fe
     $response->assertDontSee($feedback->user->name);
 });
 
-test('given pending and stashed feedback, when visiting the controller profile, then that feedback is not shown', function () {
+test('given pending and stashed feedback, when the controller views their own profile, then that feedback is not shown', function () {
     $controller = User::factory()->create();
     Feedback::factory()->create([
         'controller_id' => $controller->id,
@@ -299,11 +317,61 @@ test('given pending and stashed feedback, when visiting the controller profile, 
         'status' => FeedbackStatus::STASHED,
     ]);
 
-    $response = $this->get(route('users.show', [$controller->id]));
+    $response = $this->actingAs($controller)->get(route('users.show.feedback', [$controller->id]));
 
     $response->assertOk();
     $response->assertDontSee('Pending feedback comment text.');
     $response->assertDontSee('Stashed feedback comment text.');
+});
+
+test('given a guest, when visiting a controller feedback page, then they are redirected to login', function () {
+    $controller = User::factory()->create(['rostered' => true]);
+
+    $response = $this->get(route('users.show.feedback', [$controller->id]));
+
+    $response->assertRedirect(route('login'));
+});
+
+test('given another user, when visiting a controller feedback page, then the request is forbidden', function () {
+    $controller = User::factory()->create(['rostered' => true]);
+    $other = User::factory()->create();
+
+    Feedback::factory()->create([
+        'controller_id' => $controller->id,
+        'comments' => 'Released feedback comment text.',
+        'status' => FeedbackStatus::RELEASED,
+    ]);
+
+    $response = $this->actingAs($other)->get(route('users.show.feedback', [$controller->id]));
+
+    $response->assertForbidden();
+});
+
+test('given a staff member with feedback read permission, when visiting a controller feedback page, then the feedback is shown', function () {
+    $controller = User::factory()->create(['rostered' => true]);
+    $staff = User::factory()->create();
+    $staff->assignRole('staff');
+
+    Feedback::factory()->create([
+        'controller_id' => $controller->id,
+        'comments' => 'Released feedback comment text.',
+        'status' => FeedbackStatus::RELEASED,
+    ]);
+
+    $response = $this->actingAs($staff)->get(route('users.show.feedback', [$controller->id]));
+
+    $response->assertOk();
+    $response->assertSee('Released feedback comment text.');
+});
+
+test('given another user, when visiting a controller profile, then the feedback tab is not shown', function () {
+    $controller = User::factory()->create(['rostered' => true]);
+    $other = User::factory()->create();
+
+    $response = $this->actingAs($other)->get(route('users.show', [$controller->id]));
+
+    $response->assertOk();
+    $response->assertDontSee(route('users.show.feedback', [$controller->id]));
 });
 
 // Email notifications & user-visible comments (issue #179)
@@ -409,4 +477,32 @@ test('given an admin, when releasing feedback, then the controller is emailed', 
     Mail::assertQueued(FeedbackReceived::class, function ($mail) use ($feedback) {
         return $mail->hasTo($feedback->controller->email) && $mail->feedback->is($feedback);
     });
+});
+
+test('given a rostered controller, when submitting feedback, then the request is forbidden', function () {
+    $rostered = User::factory()->create();
+    $rostered->assignRole('rostered');
+
+    $controller = User::factory()->create(['rostered' => true]);
+
+    $response = $this->actingAs($rostered)->post(route('feedback.store'), [
+        'controller_id' => $controller->id,
+        'position' => 'JAX_TWR',
+        'experience' => 'Good',
+        'comments' => 'Should not be allowed.',
+    ]);
+
+    $response->assertForbidden();
+    expect(Feedback::count())->toBe(0);
+});
+
+test('given a rostered controller, when visiting the feedback page, then the submit form is not shown', function () {
+    $rostered = User::factory()->create();
+    $rostered->assignRole('rostered');
+
+    $response = $this->actingAs($rostered)->get(route('feedback.index'));
+
+    $response->assertOk();
+    $response->assertSee('Rostered controllers cannot submit feedback.');
+    $response->assertDontSee('Submit Feedback</button>', false);
 });

--- a/tests/Feature/FeedbackTest.php
+++ b/tests/Feature/FeedbackTest.php
@@ -3,9 +3,12 @@
 use App\Enums\FeedbackExperience;
 use App\Enums\FeedbackStatus;
 use App\Jobs\SendFeedbackToWebhook;
+use App\Mail\FeedbackCommentPosted;
+use App\Mail\FeedbackReleased;
 use App\Models\Feedback;
 use App\Models\User;
 use Database\Seeders\PermissionSeeder;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
@@ -264,4 +267,129 @@ test('given an admin, when posting an empty staff comment, then a comment error 
 
     $response->assertSessionHasErrors('comment');
     expect($feedback->staffComments()->count())->toBe(0);
+});
+
+// Feedback on controller profile
+
+test('given released feedback, when visiting the controller profile, then the feedback is shown without the submitter identity', function () {
+    $feedback = Feedback::factory()->create([
+        'position' => 'JAX_TWR',
+        'comments' => 'Great service on tower frequency.',
+        'status' => FeedbackStatus::RELEASED,
+    ]);
+
+    $response = $this->get(route('users.show', [$feedback->controller_id]));
+
+    $response->assertOk();
+    $response->assertSee('Great service on tower frequency.');
+    $response->assertSee('JAX_TWR');
+    $response->assertDontSee($feedback->user->name);
+});
+
+test('given pending and stashed feedback, when visiting the controller profile, then that feedback is not shown', function () {
+    $controller = User::factory()->create();
+    Feedback::factory()->create([
+        'controller_id' => $controller->id,
+        'comments' => 'Pending feedback comment text.',
+    ]);
+    Feedback::factory()->create([
+        'controller_id' => $controller->id,
+        'comments' => 'Stashed feedback comment text.',
+        'status' => FeedbackStatus::STASHED,
+    ]);
+
+    $response = $this->get(route('users.show', [$controller->id]));
+
+    $response->assertOk();
+    $response->assertDontSee('Pending feedback comment text.');
+    $response->assertDontSee('Stashed feedback comment text.');
+});
+
+// Email notifications & user-visible comments (issue #179)
+
+test('given an admin, when releasing feedback, then the submitter is emailed', function () {
+    Queue::fake();
+    Mail::fake();
+
+    $admin = User::factory()->create();
+    $admin->assignRole(['staff', 'admin']);
+
+    $feedback = Feedback::factory()->create();
+
+    $this->actingAs($admin)->put(route('admin.feedback.release', [$feedback]));
+
+    Mail::assertQueued(FeedbackReleased::class, function ($mail) use ($feedback) {
+        return $mail->hasTo($feedback->user->email) && $mail->feedback->is($feedback);
+    });
+});
+
+test('given an admin, when posting a user-visible comment, then it is stored as visible and the submitter is emailed', function () {
+    Mail::fake();
+
+    $admin = User::factory()->create();
+    $admin->assignRole(['staff', 'admin']);
+
+    $feedback = Feedback::factory()->create();
+
+    $response = $this->actingAs($admin)->post(route('admin.feedback.comments.store', [$feedback]), [
+        'comment' => 'This will be shared with the submitter.',
+        'user_visible' => '1',
+    ]);
+
+    $response->assertRedirect(route('admin.feedback.show', [$feedback]));
+
+    $comment = $feedback->staffComments()->sole();
+    expect($comment->user_visible)->toBeTrue();
+
+    Mail::assertQueued(FeedbackCommentPosted::class, function ($mail) use ($feedback) {
+        return $mail->hasTo($feedback->user->email);
+    });
+});
+
+test('given an admin, when posting a comment without marking it visible, then it is internal and no email is sent', function () {
+    Mail::fake();
+
+    $admin = User::factory()->create();
+    $admin->assignRole(['staff', 'admin']);
+
+    $feedback = Feedback::factory()->create();
+
+    $this->actingAs($admin)->post(route('admin.feedback.comments.store', [$feedback]), [
+        'comment' => 'Internal note only.',
+    ]);
+
+    $comment = $feedback->staffComments()->sole();
+    expect($comment->user_visible)->toBeFalse();
+
+    Mail::assertNotQueued(FeedbackCommentPosted::class);
+});
+
+test('given a user with feedback, when visiting the feedback page, then their feedback and visible staff comments are shown', function () {
+    $user = User::factory()->create();
+    $staff = User::factory()->create();
+
+    $feedback = Feedback::factory()->create([
+        'user_id' => $user->id,
+        'comments' => 'My original feedback text.',
+    ]);
+    $feedback->staffComments()->create([
+        'user_id' => $staff->id,
+        'comment' => 'A visible staff reply.',
+        'user_visible' => true,
+    ]);
+    $feedback->staffComments()->create([
+        'user_id' => $staff->id,
+        'comment' => 'An internal staff note.',
+        'user_visible' => false,
+    ]);
+
+    $otherFeedback = Feedback::factory()->create(['comments' => 'Somebody elses feedback.']);
+
+    $response = $this->actingAs($user)->get(route('feedback.index'));
+
+    $response->assertOk();
+    $response->assertSee('My original feedback text.');
+    $response->assertSee('A visible staff reply.');
+    $response->assertDontSee('An internal staff note.');
+    $response->assertDontSee('Somebody elses feedback.');
 });

--- a/tests/Feature/FeedbackTest.php
+++ b/tests/Feature/FeedbackTest.php
@@ -4,6 +4,7 @@ use App\Enums\FeedbackExperience;
 use App\Enums\FeedbackStatus;
 use App\Jobs\SendFeedbackToWebhook;
 use App\Mail\FeedbackCommentPosted;
+use App\Mail\FeedbackReceived;
 use App\Mail\FeedbackReleased;
 use App\Models\Feedback;
 use App\Models\User;
@@ -392,4 +393,20 @@ test('given a user with feedback, when visiting the feedback page, then their fe
     $response->assertSee('A visible staff reply.');
     $response->assertDontSee('An internal staff note.');
     $response->assertDontSee('Somebody elses feedback.');
+});
+
+test('given an admin, when releasing feedback, then the controller is emailed', function () {
+    Queue::fake();
+    Mail::fake();
+
+    $admin = User::factory()->create();
+    $admin->assignRole(['staff', 'admin']);
+
+    $feedback = Feedback::factory()->create();
+
+    $this->actingAs($admin)->put(route('admin.feedback.release', [$feedback]));
+
+    Mail::assertQueued(FeedbackReceived::class, function ($mail) use ($feedback) {
+        return $mail->hasTo($feedback->controller->email) && $mail->feedback->is($feedback);
+    });
 });


### PR DESCRIPTION
closes #148 #179 

- there is now a controller feedback page accessible to anyone is logged into an authenticated VATSIM account
- feedback now shows on controller profile
- submitted feedback on the /feedback page now has a status "pending review" or "submitted". it does not show stashed feedback, it'll just keep it as "pending"
- staff comments can be "visible to the submitter." i might remove this and keep it as more of a backend system. thats how the previous system was. however this is more intuative. 

screenshots of the system:
<img width="1142" height="1895" alt="image" src="https://github.com/user-attachments/assets/b1a884f4-04c6-4c95-9210-a5532cbd0c79" />
<img width="1914" height="1302" alt="image" src="https://github.com/user-attachments/assets/f17a06f9-9654-46a1-9d6d-d8b53fc368e2" />
<img width="1905" height="1279" alt="image" src="https://github.com/user-attachments/assets/4e7c8d08-86cd-4585-9988-7c68f8b26d14" />
<img width="1244" height="1539" alt="image" src="https://github.com/user-attachments/assets/28a84caf-8d2d-43c7-bb07-3cb94136ac0f" />
<img width="3196" height="872" alt="image" src="https://github.com/user-attachments/assets/b7423d25-2167-451a-abb0-d65a2f061058" />
<img width="3286" height="816" alt="image" src="https://github.com/user-attachments/assets/c1ede7a7-aa2e-4e16-879a-e2d9360c9dda" />
<img width="2859" height="759" alt="image" src="https://github.com/user-attachments/assets/71a253ee-51d7-4fce-9c43-fb789be6714b" />


