### PR TITLE
[security] Add secret redaction, force ipv4

### DIFF
--- a/app/Jobs/SyncRoster.php
+++ b/app/Jobs/SyncRoster.php
@@ -35,7 +35,7 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     {
         $ROSTER_API_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility').'/roster/both';
 
-        $rosterData = Http::get($ROSTER_API_ENDPOINT, [
+        $rosterData = Http::retry(2, 500)->timeout(20)->get($ROSTER_API_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
 
@@ -120,7 +120,7 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
     private function updateStaffMembers()
     {
         $FACILITY_INFO_ENDPOINT = config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility');
-        $facilityInfo = Http::get($FACILITY_INFO_ENDPOINT, [
+        $facilityInfo = Http::retry(2, 500)->timeout(20)->get($FACILITY_INFO_ENDPOINT, [
             'apikey' => config('app.vatusa_api_key'),
         ]);
 
@@ -167,7 +167,7 @@ class SyncRoster implements ShouldBeUnique, ShouldQueue
             Log::info('Roster sync completed successfully.');
         } catch (\Exception $e) {
             // Log error
-            Log::error('Error syncing roster: '.$e->getMessage().'\n'.$e->getTraceAsString(), [
+            Log::error('Error syncing roster: '.$e->getMessage()."\n".$e->getTraceAsString(), [
                 'url' => config('app.vatusa_api_url').'/v2/facility/'.config('app.vatusa_facility'),
                 'environment' => App::environment(),
                 'exception' => get_class($e),

--- a/app/Jobs/UpdateOnlineControllers.php
+++ b/app/Jobs/UpdateOnlineControllers.php
@@ -8,6 +8,7 @@ use App\Models\StatisticsPrefixes;
 use Http;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Str;
 
 class UpdateOnlineControllers implements ShouldQueue
@@ -26,9 +27,22 @@ class UpdateOnlineControllers implements ShouldQueue
     {
         $API_ENDPOINT = config('app.vatsim_api_url').'/v2/atc/online';
 
-        $onlineData = Http::get($API_ENDPOINT);
+        try {
+            $onlineData = Http::retry(2, 500)->timeout(20)->get($API_ENDPOINT);
+        } catch (\Exception $e) {
+            Log::error('Failed to fetch VATSIM online controllers: '.$e->getMessage());
+
+            return;
+        }
 
         $controllers = json_decode($onlineData, true);
+
+        if (! is_array($controllers)) {
+            Log::error('VATSIM online controllers endpoint returned an unexpected payload.');
+
+            return;
+        }
+
         $prefixes = StatisticsPrefixes::pluck('name')->toArray();
         OnlineController::truncate();
 

--- a/app/Logging/RedactSecrets.php
+++ b/app/Logging/RedactSecrets.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\LogRecord;
+
+/**
+ * Log tap that strips known API keys/secrets out of log messages and context
+ * before they reach a handler (file, Discord webhook, etc). Exception messages
+ * from HTTP clients often embed the full request URL — including any secret
+ * passed as a query parameter — so this runs on every record, not just ones we
+ * expect to contain a secret.
+ */
+class RedactSecrets
+{
+    public function __invoke(Logger $logger): void
+    {
+        $logger->pushProcessor(function (LogRecord $record): LogRecord {
+            $secrets = array_values(array_filter([
+                config('app.vatusa_api_key'),
+                config('app.vatsim_client_secret'),
+                config('app.statsim_api_key'),
+            ], fn ($secret) => is_string($secret) && $secret !== ''));
+
+            if ($secrets === []) {
+                return $record;
+            }
+
+            return $record->with(
+                message: str_replace($secrets, '[REDACTED]', $record->message),
+                context: $this->redact($record->context, $secrets),
+            );
+        });
+    }
+
+    private function redact(array $data, array $secrets): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $data[$key] = str_replace($secrets, '[REDACTED]', $value);
+            } elseif (is_array($value)) {
+                $data[$key] = $this->redact($value, $secrets);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -247,7 +247,7 @@ class User extends Authenticatable
 
     public static function createFromVatusa(int $id)
     {
-        $userData = Http::get(config('app.vatusa_api_url').'/v2/user/'.$id, [
+        $userData = Http::retry(2, 500)->timeout(20)->get(config('app.vatusa_api_url').'/v2/user/'.$id, [
             'apikey' => config('app.vatusa_api_key'),
         ])->throw()->json()['data'] ?? throw new \Exception('Failed to fetch user data for CID '.$id);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Services\Socialite\VatsimProvider;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -13,7 +15,17 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Bounded Guzzle client used by the Discord log channel (marvinlabs/laravel-discord-logger)
+        // so a slow/unreachable Discord webhook can't hang or re-throw out of a Log:: call.
+        $this->app->singleton(Client::class, function () {
+            return new Client([
+                'timeout' => 5,
+                'connect_timeout' => 3,
+                'curl' => [
+                    CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+                ],
+            ]);
+        });
     }
 
     /**
@@ -37,5 +49,13 @@ class AppServiceProvider extends ServiceProvider
 
             return $socialite->buildProvider(VatsimProvider::class, $config);
         });
+
+        // Force IPv4 for every outbound Http:: facade call (VATUSA/VATSIM/STATSIM/GitHub) —
+        // rules out flaky/blackholed IPv6 routing as a source of intermittent connect timeouts.
+        Http::globalOptions([
+            'curl' => [
+                CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+            ],
+        ]);
     }
 }

--- a/app/Services/VisitingChecklistService.php
+++ b/app/Services/VisitingChecklistService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\DTOs\VisitingChecklistDTO;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class VisitingChecklistService
 {
@@ -11,9 +12,15 @@ class VisitingChecklistService
     {
         $url = config('app.vatusa_api_url').'/v2/user/'.$cid.'/transfer/checklist';
 
-        $response = Http::get($url, [
-            'apikey' => config('app.vatusa_api_key'),
-        ]);
+        try {
+            $response = Http::retry(2, 500)->timeout(20)->get($url, [
+                'apikey' => config('app.vatusa_api_key'),
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to fetch VATUSA visiting checklist for CID '.$cid.': '.$e->getMessage());
+
+            return new VisitingChecklistDTO(null);
+        }
 
         if ($response->status() !== 200) {
             return new VisitingChecklistDTO(null);

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\RedactSecrets;
 use MarvinLabs\DiscordLogger\Logger;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
@@ -57,7 +58,8 @@ return [
             'via' => Logger::class,
             'level' => 'debug',
             'url' => env('LOG_DISCORD_WEBHOOK_URL'),
-            'ignore_exceptions' => env('LOG_DISCORD_IGNORE_EXCEPTIONS', false),
+            'ignore_exceptions' => env('LOG_DISCORD_IGNORE_EXCEPTIONS', true),
+            'tap' => [RedactSecrets::class],
         ],
         'stack' => [
             'driver' => 'stack',

--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,13 @@ return [
         'client_id' => env('VATSIM_CLIENT_ID'),
         'client_secret' => env('VATSIM_CLIENT_SECRET'),
         'redirect' => env('APP_URL', 'invalid_config').'/auth/callback',
+        'guzzle' => [
+            'timeout' => 15,
+            'connect_timeout' => 5,
+            'curl' => [
+                CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+            ],
+        ],
     ],
 
 ];


### PR DESCRIPTION
Adds secret redaction to discord logs, forces all HTTP requests to be IPv4 since vatusa only uses IPV4 for some stupid reason