### PR TITLE
Fix the earliest month shown on all-time statistics

### DIFF
--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -142,9 +142,9 @@ class StatisticsController extends Controller
             'SUM(delivery_hours + ground_hours + tower_hours + approach_hours + center_hours) as total'
         )->value('total') ?? 0;
 
-        $earliest = ControllerMonthlyStat::selectRaw('MIN(year * 100 + month) as ym, MIN(year) as y, MIN(month) as m')->first();
-        $allTimeSince = ($earliest && $earliest->y)
-            ? Carbon::create($earliest->y, $earliest->m, 1)->format('M Y')
+        $earliestYearMonth = (int) ControllerMonthlyStat::selectRaw('MIN(year * 100 + month) as ym')->value('ym');
+        $allTimeSince = $earliestYearMonth > 0
+            ? Carbon::create(intdiv($earliestYearMonth, 100), $earliestYearMonth % 100, 1)->format('M Y')
             : null;
 
         return view('statistics.index', [

--- a/tests/Feature/StatisticsLeaderboardTest.php
+++ b/tests/Feature/StatisticsLeaderboardTest.php
@@ -38,3 +38,26 @@ test('all-months leaderboard sums each controllers hours in SQL', function () {
     // One aggregated row per controller, not one row per monthly record.
     expect($stats->where('user_id', $user->id))->toHaveCount(1);
 });
+
+test('the all-time label uses the earliest year and month that actually occurred together', function () {
+    $user = User::factory()->create(['rostered' => true, 'rating' => 5]);
+
+    foreach ([[2025, 6], [2025, 11], [2026, 1], [2026, 8]] as [$year, $month]) {
+        ControllerMonthlyStat::create([
+            'user_id' => $user->id, 'year' => $year, 'month' => $month,
+            'delivery_hours' => 1, 'ground_hours' => 0, 'tower_hours' => 0,
+            'approach_hours' => 0, 'center_hours' => 0,
+        ]);
+    }
+
+    $response = $this->get(route('statistics.index'))->assertOk();
+
+    expect($response->viewData('allTimeSince'))->toBe('Jun 2025');
+    $response->assertSee('Total ARTCC Hours since Jun 2025');
+});
+
+test('given no statistics at all, when viewing the page, then there is no since date to label', function () {
+    $response = $this->get(route('statistics.index'))->assertOk();
+
+    expect($response->viewData('allTimeSince'))->toBeNull();
+});


### PR DESCRIPTION
Closes #213.

## The bug

The "All-Time Hours" label read **"Total ARTCC Hours since Jan 2025"** when the earliest stats are actually from later in 2025.

`StatisticsController::index` took `MIN(year)` and `MIN(month)` as two **separate** aggregates and then combined them:

```php
$earliest = ControllerMonthlyStat::selectRaw('MIN(year * 100 + month) as ym, MIN(year) as y, MIN(month) as m')->first();
$allTimeSince = ($earliest && $earliest->y)
    ? Carbon::create($earliest->y, $earliest->m, 1)->format('M Y')
    : null;
```

`MIN(year)` and `MIN(month)` come from different rows, so the label pairs the earliest year with the earliest month seen in *any* year. Data running Jun 2025 → Aug 2026 gives `MIN(year) = 2025` and `MIN(month) = 1` (January, from 2026), producing "Jan 2025" — a month with no stats at all.

The bug was dormant until the stats crossed into a second year, which is why it appeared now.

## The fix

The correct value, `MIN(year * 100 + month)`, was already being selected on that same line and simply never read. This uses it and derives the year and month back out, so the label can only ever name a month that really occurred.

## Tests

Two added to `StatisticsLeaderboardTest`:

- Stats at Jun 2025, Nov 2025, Jan 2026 and Aug 2026 must label as "Jun 2025". This fails on the old code with exactly the reported symptom (`'Jun 2025'` vs `'Jan 2025'`) and passes on the new code — it's a direct regression test for the January-in-a-later-year case.
- With no stats at all, `allTimeSince` stays null rather than rendering a bogus date.

I also grepped for the same split-aggregate pattern elsewhere; this was the only occurrence.
