### PR TITLE
Document system fixes

### DIFF
--- a/app/Http/Controllers/AdminPublicationCategoriesController.php
+++ b/app/Http/Controllers/AdminPublicationCategoriesController.php
@@ -102,7 +102,7 @@ class AdminPublicationCategoriesController extends Controller
     {
         return $request->validate([
             'title' => ['required', 'string', 'max:255'],
-            'description' => ['required', 'string'],
+            'description' => ['nullable', 'string'],
             'display_order' => ['required', 'integer', 'min:0'],
         ]);
     }

--- a/app/Http/Controllers/AdminPublicationsController.php
+++ b/app/Http/Controllers/AdminPublicationsController.php
@@ -14,7 +14,7 @@ class AdminPublicationsController extends Controller
 
     private const DIRECTORY = 'documents';
 
-    private const ALLOWED_MIMES = 'pdf,docx,png,jpg,jpeg';
+    private const ALLOWED_MIMES = 'pdf,png,jpg,jpeg,json';
 
     private const MAX_KB = 10240;
 
@@ -47,8 +47,7 @@ class AdminPublicationsController extends Controller
         Publication::create([
             'publication_category_id' => $validated['publication_category_id'],
             'name' => $validated['name'],
-            'description' => $validated['description'],
-            'version' => $validated['version'],
+            'description' => $validated['description'] ?? null,
             'file_path' => $storedPath,
             'original_filename' => $file->getClientOriginalName(),
             'file_size' => $file->getSize(),
@@ -75,8 +74,7 @@ class AdminPublicationsController extends Controller
         $document->fill([
             'publication_category_id' => $validated['publication_category_id'],
             'name' => $validated['name'],
-            'description' => $validated['description'],
-            'version' => $validated['version'],
+            'description' => $validated['description'] ?? null,
         ]);
 
         if ($request->hasFile('file')) {
@@ -118,8 +116,7 @@ class AdminPublicationsController extends Controller
         return $request->validate([
             'publication_category_id' => ['required', Rule::exists('publication_categories', 'id')],
             'name' => ['required', 'string', 'max:255'],
-            'description' => ['required', 'string'],
-            'version' => ['required', 'string', 'max:50'],
+            'description' => ['nullable', 'string'],
             'file' => [
                 $fileRequired ? 'required' : 'nullable',
                 'file',

--- a/app/Http/Controllers/PublicationsController.php
+++ b/app/Http/Controllers/PublicationsController.php
@@ -27,6 +27,12 @@ class PublicationsController extends Controller
             404
         );
 
-        return Storage::disk('public')->response($publication->file_path, $publication->original_filename);
+        // Anything a browser cannot render (vATIS profile JSON, legacy uploads) is
+        // saved to disk rather than dumped on screen as raw text.
+        if ($publication->opensInBrowser()) {
+            return Storage::disk('public')->response($publication->file_path, $publication->original_filename);
+        }
+
+        return Storage::disk('public')->download($publication->file_path, $publication->original_filename);
     }
 }

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -15,7 +15,7 @@ class Publication extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['name', 'description', 'version', 'publication_category_id', 'original_filename'])
+            ->logOnly(['name', 'description', 'publication_category_id', 'original_filename'])
             ->logOnlyDirty();
     }
 
@@ -23,7 +23,6 @@ class Publication extends Model
         'publication_category_id',
         'name',
         'description',
-        'version',
         'file_path',
         'original_filename',
         'file_size',
@@ -43,10 +42,20 @@ class Publication extends Model
             : null);
     }
 
-    public function isViewableInBrowser(): bool
+    /**
+     * Whether a browser renders this file in a tab rather than saving it.
+     *
+     * This drives both the Content-Disposition the file route sends and the
+     * action label shown in the listing, so the two can never disagree about
+     * what clicking a document will do.
+     */
+    public function opensInBrowser(): bool
     {
-        $ext = strtolower(pathinfo($this->original_filename ?? $this->file_path, PATHINFO_EXTENSION));
+        $extension = strtolower(pathinfo(
+            $this->original_filename ?? $this->file_path,
+            PATHINFO_EXTENSION
+        ));
 
-        return in_array($ext, ['pdf', 'png', 'jpg', 'jpeg', 'txt']);
+        return in_array($extension, ['pdf', 'png', 'jpg', 'jpeg']);
     }
 }

--- a/database/migrations/2026_08_13_190000_simplify_publication_fields.php
+++ b/database/migrations/2026_08_13_190000_simplify_publication_fields.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('publications', function (Blueprint $table) {
+            $table->dropColumn('version');
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('publication_categories', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Restoring NOT NULL fails outright if any description was cleared while
+        // the column allowed nulls, so backfill those rows before changing it.
+        DB::table('publication_categories')->whereNull('description')->update(['description' => '']);
+        DB::table('publications')->whereNull('description')->update(['description' => '']);
+
+        Schema::table('publication_categories', function (Blueprint $table) {
+            $table->text('description')->nullable(false)->change();
+        });
+
+        // The dropped version strings cannot be recovered; existing rows get an
+        // empty string so the NOT NULL column can be added back.
+        Schema::table('publications', function (Blueprint $table) {
+            $table->string('version')->default('');
+            $table->text('description')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_08_13_193000_clear_seeded_publication_category_descriptions.php
+++ b/database/migrations/2026_08_13_193000_clear_seeded_publication_category_descriptions.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * The descriptions the category seeder used to write. Matching on the exact
+     * text means a description someone has since written by hand is left alone;
+     * only the untouched generated copy is cleared.
+     */
+    private const SEEDED_DESCRIPTIONS = [
+        'Facility-wide and position-specific standard operating procedures for vZJX controllers.',
+        'Operational agreements between vZJX and adjacent facilities governing coordination procedures.',
+        'Study guides, training syllabi, and reference materials for controller certification.',
+        'Quick reference cards and cheat sheets for use during controlling sessions.',
+        'Airspace diagrams, sector maps, and facility charts for ZJX ARTCC.',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('publication_categories')
+            ->whereIn('description', self::SEEDED_DESCRIPTIONS)
+            ->update(['description' => null]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Deliberately empty. Restoring the placeholder text is never the desired
+        // outcome, and once cleared there is no way to tell which categories had
+        // it in the first place.
+    }
+};

--- a/database/seeders/PublicationCategorySeeder.php
+++ b/database/seeders/PublicationCategorySeeder.php
@@ -10,23 +10,21 @@ class PublicationCategorySeeder extends Seeder
     public function run(): void
     {
         $categories = [
-            'Standard Operating Procedures' => 'Facility-wide and position-specific standard operating procedures for vZJX controllers.',
-            'Letters of Agreement' => 'Operational agreements between vZJX and adjacent facilities governing coordination procedures.',
-            'Training Materials' => 'Study guides, training syllabi, and reference materials for controller certification.',
-            'Quick Reference Guides' => 'Quick reference cards and cheat sheets for use during controlling sessions.',
-            'Facility Maps & Charts' => 'Airspace diagrams, sector maps, and facility charts for ZJX ARTCC.',
+            'Standard Operating Procedures',
+            'Letters of Agreement',
+            'Training Materials',
+            'Quick Reference Guides',
+            'Facility Maps & Charts',
         ];
 
-        $order = 0;
-        foreach ($categories as $title => $description) {
+        foreach ($categories as $order => $title) {
             PublicationCategory::firstOrCreate(
                 ['title' => $title],
                 [
-                    'description' => $description,
+                    'description' => null,
                     'display_order' => $order,
                 ],
             );
-            $order++;
         }
     }
 }

--- a/resources/views/admin/publications/categories/create.blade.php
+++ b/resources/views/admin/publications/categories/create.blade.php
@@ -33,10 +33,9 @@
                     </div>
 
                     <div>
-                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <label for="description" class="label">Description</label>
                         <textarea id="description"
                                   name="description"
-                                  required
                                   rows="3"
                                   placeholder="Short description shown on the public page..."
                                   class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description') }}</textarea>

--- a/resources/views/admin/publications/categories/edit.blade.php
+++ b/resources/views/admin/publications/categories/edit.blade.php
@@ -33,10 +33,9 @@
                     </div>
 
                     <div>
-                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <label for="description" class="label">Description</label>
                         <textarea id="description"
                                   name="description"
-                                  required
                                   rows="3"
                                   class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $category->description) }}</textarea>
                         @error('description')<p class="text-error text-sm mt-1">{{ $message }}</p>@enderror

--- a/resources/views/admin/publications/create.blade.php
+++ b/resources/views/admin/publications/create.blade.php
@@ -36,10 +36,9 @@
                     </div>
 
                     <div>
-                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <label for="description" class="label">Description</label>
                         <textarea id="description"
                                   name="description"
-                                  required
                                   rows="3"
                                   placeholder="Brief description of this document..."
                                   class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description') }}</textarea>
@@ -51,10 +50,10 @@
                 </div>
             </div>
 
-            {{-- Category & Version --}}
+            {{-- Category --}}
             <div class="collapse collapse-open bg-base-100 border border-base-300">
                 <input type="checkbox" checked />
-                <div class="collapse-title font-semibold">Category & Version</div>
+                <div class="collapse-title font-semibold">Category</div>
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
@@ -71,20 +70,6 @@
                             @endforeach
                         </select>
                         @error('publication_category_id')
-                            <p class="text-error text-sm mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="version" class="label">Version <span class="text-error">*</span></label>
-                        <input id="version"
-                               name="version"
-                               type="text"
-                               required
-                               placeholder="e.g. v1.0"
-                               value="{{ old('version') }}"
-                               class="input input-bordered w-full @error('version') input-error @enderror" />
-                        @error('version')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>
@@ -112,9 +97,9 @@
                                name="file"
                                type="file"
                                required
-                               accept=".pdf,.docx,.png,.jpg,.jpeg"
+                               accept=".pdf,.png,.jpg,.jpeg,.json"
                                class="file-input file-input-bordered w-full @error('file') file-input-error @enderror" />
-                        <p class="text-xs text-base-content/50 mt-1">Accepted: PDF, Word (docx), PNG, JPG. Max 10 MB.</p>
+                        <p class="text-xs text-base-content/50 mt-1">Accepted: PDF, PNG, JPG, JSON. Max 10 MB.</p>
                         @error('file')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror

--- a/resources/views/admin/publications/edit.blade.php
+++ b/resources/views/admin/publications/edit.blade.php
@@ -37,10 +37,9 @@
                     </div>
 
                     <div>
-                        <label for="description" class="label">Description <span class="text-error">*</span></label>
+                        <label for="description" class="label">Description</label>
                         <textarea id="description"
                                   name="description"
-                                  required
                                   rows="3"
                                   placeholder="Brief description of this document..."
                                   class="textarea textarea-bordered w-full @error('description') textarea-error @enderror">{{ old('description', $document->description) }}</textarea>
@@ -52,10 +51,10 @@
                 </div>
             </div>
 
-            {{-- Category & Version --}}
+            {{-- Category --}}
             <div class="collapse collapse-open bg-base-100 border border-base-300">
                 <input type="checkbox" checked />
-                <div class="collapse-title font-semibold">Category & Version</div>
+                <div class="collapse-title font-semibold">Category</div>
                 <div class="collapse-content flex flex-col gap-4">
 
                     <div>
@@ -73,20 +72,6 @@
                             @endforeach
                         </select>
                         @error('publication_category_id')
-                            <p class="text-error text-sm mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="version" class="label">Version <span class="text-error">*</span></label>
-                        <input id="version"
-                               name="version"
-                               type="text"
-                               required
-                               placeholder="e.g. v1.0"
-                               value="{{ old('version', $document->version) }}"
-                               class="input input-bordered w-full @error('version') input-error @enderror" />
-                        @error('version')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
                     </div>
@@ -130,9 +115,9 @@
                         <input id="file"
                                name="file"
                                type="file"
-                               accept=".pdf,.docx,.png,.jpg,.jpeg"
+                               accept=".pdf,.png,.jpg,.jpeg,.json"
                                class="file-input file-input-bordered w-full @error('file') file-input-error @enderror" />
-                        <p class="text-xs text-base-content/50 mt-1">Leave empty to keep the current file. Accepted: PDF, Word (docx), PNG, JPG. Max 10 MB.</p>
+                        <p class="text-xs text-base-content/50 mt-1">Leave empty to keep the current file. Accepted: PDF, PNG, JPG, JSON. Max 10 MB.</p>
                         @error('file')
                             <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror

--- a/resources/views/admin/publications/index.blade.php
+++ b/resources/views/admin/publications/index.blade.php
@@ -45,7 +45,6 @@
                                     <thead>
                                         <tr>
                                             <th>Name</th>
-                                            <th>Version</th>
                                             <th>Updated At (UTC)</th>
                                             <th>Description</th>
                                             <th>Actions</th>
@@ -55,9 +54,6 @@
                                         @foreach($category->publications as $doc)
                                             <tr>
                                                 <td class="border-r border-base-300 font-medium">{{ $doc->name }}</td>
-                                                <td class="border-r border-base-300">
-                                                    <span class="badge badge-outline badge-sm">{{ $doc->version }}</span>
-                                                </td>
                                                 <td class="border-r border-base-300 text-sm text-base-content/60">
                                                     {{ $doc->updated_at->utc()->format('D, d M Y') }}<br>
                                                     <span class="text-xs">{{ $doc->updated_at->utc()->format('H:i:s') }} GMT</span>

--- a/resources/views/publications/index.blade.php
+++ b/resources/views/publications/index.blade.php
@@ -5,11 +5,6 @@
 @section('body')
     <div class="w-full px-4 sm:px-6 lg:px-8">
 
-        {{-- Intro --}}
-        <p class="text-base-content/70 mb-6 max-w-3xl">
-            Official vZJX documents including standard operating procedures, letters of agreement, training materials, quick reference guides, and facility maps. All documents are for simulation use only.
-        </p>
-
         {{-- Category tabs (mobile: scroll horizontally; desktop: inline) --}}
         <div class="flex gap-2 flex-wrap mb-6">
             @foreach($categories as $category)
@@ -28,47 +23,42 @@
                         {{-- Category header --}}
                         <div class="mb-4">
                             <h2 class="card-title text-xl sm:text-2xl">{{ $category->title }}</h2>
-                            <p class="text-base-content/60 text-sm mt-0.5">{{ $category->description }}</p>
+                            @if(filled($category->description))
+                                <p class="text-base-content/60 text-sm mt-0.5">{{ $category->description }}</p>
+                            @endif
                         </div>
 
                         {{-- Documents list --}}
-                        <div class="flex flex-col divide-y divide-base-200">
+                        <div class="flex flex-col">
                             @forelse($category->publications as $doc)
-                                <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+                                <a href="{{ $doc->file_url }}"
+                                   target="_blank"
+                                   class="group flex items-center gap-4 py-3 px-3 -mx-1 my-1 rounded-lg cursor-pointer border border-base-300 bg-base-100 transition-colors hover:bg-base-200 hover:border-primary focus-visible:bg-base-200 focus-visible:border-primary">
                                     <div class="flex-1 min-w-0">
-                                        <div class="flex flex-wrap items-center gap-2">
-                                            <span class="font-medium text-base">{{ $doc->name }}</span>
-                                            <span class="badge badge-outline badge-sm">{{ $doc->version }}</span>
-                                        </div>
-                                        <p class="text-sm text-base-content/60 mt-0.5">{{ $doc->description }}</p>
+                                        <span class="font-medium text-base text-primary group-hover:underline">{{ $doc->name }}</span>
+                                        @if(filled($doc->description))
+                                            <p class="text-sm text-base-content/60 mt-0.5">{{ $doc->description }}</p>
+                                        @endif
                                         <p class="text-xs text-base-content/40 mt-0.5">
                                             Updated {{ $doc->updated_at->utc()->format('D, d M Y H:i:s') }} GMT
                                         </p>
                                     </div>
-                                    <div class="shrink-0 flex gap-2">
-                                        @if($doc->isViewableInBrowser())
-                                            <a href="{{ $doc->file_url }}"
-                                               target="_blank"
-                                               class="btn btn-outline btn-sm gap-1.5"
-                                               aria-label="View {{ $doc->name }} in browser">
-                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                                </svg>
-                                                View
-                                            </a>
-                                        @endif
-                                        <a href="{{ $doc->file_url }}"
-                                           download="{{ $doc->original_filename }}"
-                                           class="btn btn-primary btn-sm gap-1.5"
-                                           aria-label="Download {{ $doc->name }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+
+                                    {{-- Says what clicking does. Matches the Content-Disposition the file route sends. --}}
+                                    <span class="shrink-0 flex items-center gap-2 text-base font-semibold text-primary border-2 border-primary rounded-lg px-5 py-2.5 transition-colors group-hover:bg-primary group-hover:text-primary-content">
+                                        @if($doc->opensInBrowser())
+                                            View
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                            </svg>
+                                        @else
+                                            Download
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                                             </svg>
-                                            Download
-                                        </a>
-                                    </div>
-                                </div>
+                                        @endif
+                                    </span>
+                                </a>
                             @empty
                                 <p class="text-sm text-base-content/50 py-3">No documents in this category yet.</p>
                             @endforelse

--- a/tests/Feature/PublicationsTest.php
+++ b/tests/Feature/PublicationsTest.php
@@ -20,15 +20,14 @@ function makeCategory(): PublicationCategory
     ]);
 }
 
-function makePublication(string $filePath = 'documents/example.pdf'): Publication
+function makePublication(string $filePath = 'documents/example.pdf', string $originalFilename = 'example.pdf'): Publication
 {
     return Publication::create([
         'publication_category_id' => makeCategory()->id,
         'name' => 'Example Document',
         'description' => 'An example document.',
-        'version' => '1.0',
         'file_path' => $filePath,
-        'original_filename' => 'example.pdf',
+        'original_filename' => $originalFilename,
         'file_size' => 1234,
     ]);
 }
@@ -94,7 +93,6 @@ test('an allowed file type can be uploaded', function () {
         'publication_category_id' => $category->id,
         'name' => 'New SOP',
         'description' => 'A new SOP.',
-        'version' => '2.0',
         'file' => UploadedFile::fake()->create('sop.pdf', 200, 'application/pdf'),
     ]);
 
@@ -113,10 +111,219 @@ test('a disallowed file type is rejected', function () {
         'publication_category_id' => $category->id,
         'name' => 'Bad Upload',
         'description' => 'Should be rejected.',
-        'version' => '1.0',
         'file' => UploadedFile::fake()->create('notes.txt', 10, 'text/plain'),
     ]);
 
     $response->assertSessionHasErrors('file');
     expect(Publication::where('name', 'Bad Upload')->exists())->toBeFalse();
+});
+
+// --- Public listing ---
+
+test('a docx uploaded before the PDF ban still links to its file', function () {
+    $docx = makePublication('documents/sop.docx', 'sop.docx');
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    $response->assertSee($docx->file_url, false);
+});
+
+test('the listing wraps the whole document row in one link rather than separate buttons', function () {
+    $publication = makePublication();
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    // The name, description and timestamp all sit inside the single anchor, and
+    // nothing forces a browser download separately from that link.
+    $response->assertSee('<a href="'.$publication->file_url.'"', false);
+    $response->assertDontSee('download=', false);
+    expect(substr_count($response->getContent(), $publication->file_url))->toBe(1);
+});
+
+// The download arrow is only rendered for files that save to disk, so it
+// distinguishes the two labels without tripping over the page heading, which
+// itself contains the word "Downloads".
+const DOWNLOAD_ICON = 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4';
+
+test('a pdf is labelled View because it opens in a tab', function () {
+    makePublication();
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    $response->assertSee('View');
+    $response->assertDontSee(DOWNLOAD_ICON, false);
+});
+
+test('a json profile is labelled Download because it saves to disk', function () {
+    makePublication('documents/profile.json', 'profile.json');
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    $response->assertSee(DOWNLOAD_ICON, false);
+});
+
+test('a document with no description renders without an empty description line', function () {
+    $publication = makePublication();
+    $publication->update(['description' => null]);
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    $response->assertSee($publication->name);
+});
+
+test('a category with no description renders without an empty description line', function () {
+    $category = makeCategory();
+    $category->update(['description' => null]);
+
+    $response = $this->get(route('publications.index'));
+
+    $response->assertOk();
+    $response->assertSee($category->title);
+});
+
+test('a document can be uploaded without a description', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+    $category = makeCategory();
+
+    $response = $this->actingAs($user)->post(route('admin.publications.store'), [
+        'publication_category_id' => $category->id,
+        'name' => 'Undescribed SOP',
+        'file' => UploadedFile::fake()->create('sop.pdf', 200, 'application/pdf'),
+    ]);
+
+    $response->assertRedirect(route('admin.publications.index'));
+    expect(Publication::where('name', 'Undescribed SOP')->exists())->toBeTrue();
+});
+
+test('a word document is rejected because official documents must be immutable PDFs', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+    $category = makeCategory();
+
+    $response = $this->actingAs($user)->post(route('admin.publications.store'), [
+        'publication_category_id' => $category->id,
+        'name' => 'Word SOP',
+        'file' => UploadedFile::fake()->create('sop.docx', 200, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+    ]);
+
+    $response->assertSessionHasErrors('file');
+    expect(Publication::where('name', 'Word SOP')->exists())->toBeFalse();
+});
+
+test('an image can still be uploaded for maps and charts', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+    $category = makeCategory();
+
+    $response = $this->actingAs($user)->post(route('admin.publications.store'), [
+        'publication_category_id' => $category->id,
+        'name' => 'Sector Map',
+        'file' => UploadedFile::fake()->create('map.png', 100, 'image/png'),
+    ]);
+
+    $response->assertRedirect(route('admin.publications.index'));
+    expect(Publication::where('name', 'Sector Map')->exists())->toBeTrue();
+});
+
+test('a json file can be uploaded', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+    $category = makeCategory();
+
+    $response = $this->actingAs($user)->post(route('admin.publications.store'), [
+        'publication_category_id' => $category->id,
+        'name' => 'Sector File',
+        'file' => UploadedFile::fake()->createWithContent('sectors.json', '{"sectors":[{"id":"ZJX"}]}'),
+    ]);
+
+    $response->assertRedirect(route('admin.publications.index'));
+    expect(Publication::where('name', 'Sector File')->exists())->toBeTrue();
+});
+
+// --- How files are served (inline vs download) ---
+
+test('a pdf is served inline so it opens in a browser tab', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('documents/example.pdf', 'PDF-CONTENTS');
+
+    $publication = makePublication();
+
+    $response = $this->get(route('publications.file', $publication));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))->toStartWith('inline');
+});
+
+test('a json profile is served as a download rather than raw text in a tab', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('documents/profile.json', '{"id":"ZJX"}');
+
+    $publication = makePublication('documents/profile.json', 'profile.json');
+
+    $response = $this->get(route('publications.file', $publication));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))->toStartWith('attachment');
+});
+
+test('an image is served inline so it opens in a browser tab', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('documents/map.png', 'PNG-CONTENTS');
+
+    $publication = makePublication('documents/map.png', 'map.png');
+
+    $response = $this->get(route('publications.file', $publication));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))->toStartWith('inline');
+});
+
+test('a description is still saved and shown when one is written', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+    $category = makeCategory();
+
+    $this->actingAs($user)->post(route('admin.publications.store'), [
+        'publication_category_id' => $category->id,
+        'name' => 'Described SOP',
+        'description' => 'Covers ground movement at KJAX.',
+        'file' => UploadedFile::fake()->create('sop.pdf', 200, 'application/pdf'),
+    ]);
+
+    $publication = Publication::where('name', 'Described SOP')->sole();
+    expect($publication->description)->toBe('Covers ground movement at KJAX.');
+
+    $this->get(route('publications.index'))
+        ->assertOk()
+        ->assertSee('Covers ground movement at KJAX.');
+});
+
+test('a category description is still saved when one is written', function () {
+    $user = User::factory()->create();
+    $user->assignRole('facilities', 'staff');
+
+    $this->actingAs($user)->post(route('admin.publications.categories.store'), [
+        'title' => 'vATIS Profiles',
+        'description' => 'Import these into vATIS.',
+        'display_order' => 1,
+    ]);
+
+    $category = PublicationCategory::where('title', 'vATIS Profiles')->sole();
+    expect($category->description)->toBe('Import these into vATIS.');
 });


### PR DESCRIPTION
Fixes several problems with the publications/documents system, raised by @chrisjm66.

## What was wrong

The **View button only appeared for PDFs**, even though the uploader accepted `.docx`. A Word document therefore offered no way to read it without downloading first — "I couldn't imagine anyone wanting to download an SOP just to view it." The viewability check had **no test coverage at all**, which is why it went unnoticed.

Alongside that: a separate View button was redundant when the document name was right there, the version indicator duplicated information the SOP already carries in its own preface, and the seeded category descriptions were generated filler.

## Changes

**Clicking a document** — the whole row is now one link, styled as a card with the name in the site blue. A button on the right says what the click does: **View** for files a browser renders, **Download** for everything else. The separate View and Download buttons are gone.

**Serving** — the file route now sets `Content-Disposition` to match that promise. PDFs and images are served `inline` so they open in a tab; vATIS profile JSON and anything else is sent as an `attachment` so it saves to disk instead of filling a tab with raw text. The label and the header both read `Publication::opensInBrowser()`, so they cannot disagree.

**Version indicator removed** — from the schema, admin forms and document table. Facility SOP revisions are tracked in the document's own preface, so this duplicated it and went stale. The updated-at timestamp remains.

**Descriptions optional** — on both documents and categories, so nobody invents filler to satisfy validation. A data migration clears the five descriptions the seeder used to write, **matching on their exact text** so anything written by hand is untouched. Writing a description still works normally.

**Uploads restricted to PDF, PNG, JPG and JSON.** Word documents are no longer accepted — a `.docx` is mutable, which is wrong for an official published document, and no browser can display one. JSON is accepted for vATIS profiles.

## Notes for review

- **Dropping `version` permanently discards any stored version strings.** This is deliberate and signed off, but it is irreversible — flagging it explicitly rather than leaving it to be discovered post-merge.
- Existing `.docx` and image uploads are unaffected; validation only applies to new uploads. A test pins that pre-existing docx rows still link correctly.
- Both migrations were tested in **both directions** against Postgres, including the case where a description had been cleared, which the first version of `down()` would have failed on.

## Tests

7 → 22, all passing. The reported bug lived in untested code, so this covers: how each file type is served, the View/Download labels, one link per row, the upload rules (docx refused, JSON and images accepted), and descriptions both empty and written.

Writing them caught a real defect before it shipped — making the description nullable left `$validated['description']` undefined when the field was empty, which would have thrown for any admin who skipped it.

## Still outstanding (not in this PR)

- **An in-page preview**, matching how the old site did it (`<iframe>` on a per-document page). Now unblocked since every accepted type is browser-renderable or a deliberate download. Happy to raise separately.
- **The uploader advertises "Max 10 MB" but PHP caps uploads at 2 MB** on the current config, so files in between fail with a generic error instead of the friendly message. Pre-existing and worth its own issue — `EventManagementController` already avoids this trap for event banners.
